### PR TITLE
add health checks

### DIFF
--- a/Steamfitter.Api/Controllers/HealthCheckController.cs
+++ b/Steamfitter.Api/Controllers/HealthCheckController.cs
@@ -1,0 +1,66 @@
+/*
+Copyright 2021 Carnegie Mellon University. All Rights Reserved. 
+ Released under a MIT (SEI)-style license. See LICENSE.md in the project root for license information.
+*/
+
+using System.Net;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Swashbuckle.AspNetCore.Annotations;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using System.Threading;
+using Microsoft.AspNetCore.Authorization;
+
+namespace Steamfitter.Api.Controllers
+{    
+    [AllowAnonymous]
+    public class HealthController : BaseController
+    {
+        private readonly HealthCheckService healthCheckService;
+
+        public HealthController(HealthCheckService healthCheckService)
+        {
+            this.healthCheckService = healthCheckService;
+        }
+
+        /// <summary>
+        /// Checks the liveliness health endpoint
+        /// </summary>
+        /// <remarks>
+        /// Returns a HealthReport of the liveliness health check
+        /// </remarks>
+        /// <returns></returns>
+        [HttpGet("health/live")]
+        [ProducesResponseType(typeof(HealthReport), (int)HttpStatusCode.OK)]
+        [SwaggerOperation(OperationId = "Health_GetLiveliness")]
+        public async Task<IActionResult> GetLiveliness(CancellationToken ct)
+        {
+            HealthReport report = await this.healthCheckService.CheckHealthAsync((check) => check.Tags.Contains("live"));
+            var result = new
+            {
+                status = report.Status.ToString()
+            };
+            return report.Status == HealthStatus.Healthy ? this.Ok(result) : this.StatusCode((int)HttpStatusCode.ServiceUnavailable, result);
+        }
+
+        /// <summary>
+        /// Checks the readiness health endpoint
+        /// </summary>
+        /// <remarks>
+        /// Returns a HealthReport of the readiness health check
+        /// </remarks>
+        /// <returns></returns>
+        [HttpGet("health/ready")]
+        [ProducesResponseType(typeof(HealthReport), (int)HttpStatusCode.OK)]
+        [SwaggerOperation(OperationId = "Health_GetReadiness")]
+        public async Task<IActionResult> GetReadiness(CancellationToken ct)
+        {
+            HealthReport report = await this.healthCheckService.CheckHealthAsync((check) => check.Tags.Contains("ready"));
+            var result = new
+            {
+                status = report.Status.ToString()
+            };
+            return report.Status == HealthStatus.Healthy ? this.Ok(result) : this.StatusCode((int)HttpStatusCode.ServiceUnavailable, result);
+        }
+    }
+}  

--- a/Steamfitter.Api/Infrastructure/Extensions/DatabaseExtensions.cs
+++ b/Steamfitter.Api/Infrastructure/Extensions/DatabaseExtensions.cs
@@ -113,7 +113,7 @@ namespace Steamfitter.Api.Infrastructure.Extensions
             }
         }
 
-        private static string DbProvider(IConfiguration config)
+        public static string DbProvider(IConfiguration config)
         {
             return config.GetValue<string>("Database:Provider", "Sqlite").Trim();
         }

--- a/Steamfitter.Api/Infrastructure/HealthChecks/StackStormServiceHealthCheck.cs
+++ b/Steamfitter.Api/Infrastructure/HealthChecks/StackStormServiceHealthCheck.cs
@@ -1,0 +1,48 @@
+/*
+Copyright 2021 Carnegie Mellon University. All Rights Reserved. 
+ Released under a MIT (SEI)-style license. See LICENSE.md in the project root for license information.
+*/
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+
+namespace Steamfitter.Api.Infrastructure.HealthChecks
+{
+    public class StackStormServiceHealthCheck : IHealthCheck
+    {
+        private int _healthAllowance = 90;
+        private DateTime _lastRun = DateTime.Now;
+
+        public int HealthAllowance
+        {
+            get => _healthAllowance;
+            set => _healthAllowance = value;
+        }
+        public DateTime LastRun
+        {
+            get => _lastRun;
+            set => _lastRun = value;
+        }
+        public void CompletedRun()
+        {
+            LastRun = DateTime.Now;
+        }
+
+        public Task<HealthCheckResult> CheckHealthAsync(
+            HealthCheckContext context,
+            CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if ((DateTime.Now - LastRun).TotalSeconds < HealthAllowance)
+            {
+                return Task.FromResult(
+                    HealthCheckResult.Healthy("The StackStorm Service is responsive."));
+            }
+
+            return Task.FromResult(
+                HealthCheckResult.Unhealthy("The StackStorm Service is not responsive."));
+        }
+    }
+}

--- a/Steamfitter.Api/Infrastructure/HealthChecks/StartupHealthCheck.cs
+++ b/Steamfitter.Api/Infrastructure/HealthChecks/StartupHealthCheck.cs
@@ -1,0 +1,35 @@
+/*
+Copyright 2021 Carnegie Mellon University. All Rights Reserved. 
+ Released under a MIT (SEI)-style license. See LICENSE.md in the project root for license information.
+*/
+
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace Steamfitter.Api.Infrastructure.HealthChecks
+{
+    public class StartupHealthCheck : IHealthCheck
+    {
+        private volatile bool _startupTaskCompleted = false;
+        public bool StartupTaskCompleted
+        {
+            get => _startupTaskCompleted;
+            set => _startupTaskCompleted = value;
+        }
+
+        public Task<HealthCheckResult> CheckHealthAsync(
+            HealthCheckContext context,
+            CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (StartupTaskCompleted)
+            {
+                return Task.FromResult(
+                    HealthCheckResult.Healthy("The startup task is finished."));
+            }
+
+            return Task.FromResult(
+                HealthCheckResult.Unhealthy("The startup task is still running."));
+        }
+    }
+}

--- a/Steamfitter.Api/Infrastructure/HealthChecks/TaskMaintenanceServiceHealthCheck.cs
+++ b/Steamfitter.Api/Infrastructure/HealthChecks/TaskMaintenanceServiceHealthCheck.cs
@@ -1,0 +1,48 @@
+/*
+Copyright 2021 Carnegie Mellon University. All Rights Reserved. 
+ Released under a MIT (SEI)-style license. See LICENSE.md in the project root for license information.
+*/
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+
+namespace Steamfitter.Api.Infrastructure.HealthChecks
+{
+    public class TaskMaintenanceServiceHealthCheck : IHealthCheck
+    {
+        private int _healthAllowance = 90;
+        private DateTime _lastRun = DateTime.Now;
+
+        public int HealthAllowance
+        {
+            get => _healthAllowance;
+            set => _healthAllowance = value;
+        }
+        public DateTime LastRun
+        {
+            get => _lastRun;
+            set => _lastRun = value;
+        }
+        public void CompletedRun()
+        {
+            LastRun = DateTime.Now;
+        }
+
+        public Task<HealthCheckResult> CheckHealthAsync(
+            HealthCheckContext context,
+            CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if ((DateTime.Now - LastRun).TotalSeconds < HealthAllowance)
+            {
+                return Task.FromResult(
+                    HealthCheckResult.Healthy("The TaskMaintenance Service is responsive."));
+            }
+
+            return Task.FromResult(
+                HealthCheckResult.Unhealthy("The TaskMaintenance Service is not responsive."));
+        }
+    }
+}

--- a/Steamfitter.Api/Infrastructure/Options/VmProcessingOptions.cs
+++ b/Steamfitter.Api/Infrastructure/Options/VmProcessingOptions.cs
@@ -14,6 +14,7 @@ namespace Steamfitter.Api.Infrastructure.Options
         public string ApiPassword { get; set; }
         public int VmListUpdateIntervalMinutes { get; set; }
         public int HealthCheckSeconds { get; set; }
+        public int HealthCheckTimeoutSeconds { get; set; }
         public int TaskProcessIntervalMilliseconds { get; set; }
         public int TaskProcessMaxWaitSeconds { get; set; }
         public int ExpirationCheckSeconds { get; set; }

--- a/Steamfitter.Api/Services/TaskExecutionService.cs
+++ b/Steamfitter.Api/Services/TaskExecutionService.cs
@@ -20,6 +20,7 @@ using System.Net.Http;
 using System.Threading;
 using STT = System.Threading.Tasks;
 using Player.Vm.Api;
+using Steamfitter.Api.Infrastructure.HealthChecks;
 
 namespace Steamfitter.Api.Services
 {
@@ -37,6 +38,7 @@ namespace Steamfitter.Api.Services
         private readonly IHubContext<EngineHub> _engineHub;
         private readonly IStackStormService _stackStormService;
         private readonly IHttpClientFactory _httpClientFactory;
+        private readonly StartupHealthCheck _startupHealthCheck;
         private readonly IOptionsMonitor<Infrastructure.Options.ClientOptions> _clientOptions;
 
         public TaskExecutionService(
@@ -48,7 +50,8 @@ namespace Steamfitter.Api.Services
             IStackStormService stackStormService,
             ITaskExecutionQueue taskExecutionQueue,
             IHttpClientFactory httpClientFactory,
-            IOptionsMonitor<Infrastructure.Options.ClientOptions> clientOptions)
+            IOptionsMonitor<Infrastructure.Options.ClientOptions> clientOptions,
+            StartupHealthCheck startupHealthCheck)
         {
             _logger = logger;
             _vmTaskProcessingOptions = vmTaskProcessingOptions;
@@ -59,6 +62,7 @@ namespace Steamfitter.Api.Services
             _taskExecutionQueue = taskExecutionQueue;
             _httpClientFactory = httpClientFactory;
             _clientOptions = clientOptions;
+            _startupHealthCheck = startupHealthCheck;
         }
 
         public STT.Task StartAsync(CancellationToken cancellationToken)
@@ -106,6 +110,7 @@ namespace Steamfitter.Api.Services
                         }
                     }
                     bootstrapComplete = true;
+                    _startupHealthCheck.StartupTaskCompleted = true;
                 }
                 catch (System.Exception ex)
                 {

--- a/Steamfitter.Api/Services/TaskMaintenanceService.cs
+++ b/Steamfitter.Api/Services/TaskMaintenanceService.cs
@@ -2,24 +2,18 @@
 // Released under a MIT (SEI)-style license. See LICENSE.md in the project root for license information.
 
 using AutoMapper;
-using IdentityModel.Client;
 using Microsoft.AspNetCore.SignalR;
-using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Steamfitter.Api.Data;
-using Steamfitter.Api.Data.Models;
 using Steamfitter.Api.Hubs;
-using Steamfitter.Api.Infrastructure.Extensions;
+using Steamfitter.Api.Infrastructure.HealthChecks;
 using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Net.Http;
 using System.Threading;
 using STT = System.Threading.Tasks;
-using Player.Vm.Api;
 
 namespace Steamfitter.Api.Services
 {
@@ -34,19 +28,23 @@ namespace Steamfitter.Api.Services
         private readonly IServiceScopeFactory _scopeFactory;
         private readonly IMapper _mapper;
         private readonly IHubContext<EngineHub> _engineHub;
+        private readonly TaskMaintenanceServiceHealthCheck _taskMaintenanceServiceHealthCheck;
 
         public TaskMaintenanceService(
             ILogger<TaskMaintenanceService> logger,
             IOptionsMonitor<Infrastructure.Options.VmTaskProcessingOptions> vmTaskProcessingOptions,
             IServiceScopeFactory scopeFactory,
             IMapper mapper,
-            IHubContext<EngineHub> engineHub)
+            IHubContext<EngineHub> engineHub,
+            TaskMaintenanceServiceHealthCheck taskMaintenanceServiceHealthCheck)
         {
             _logger = logger;
             _vmTaskProcessingOptions = vmTaskProcessingOptions;
             _scopeFactory = scopeFactory;
             _mapper = mapper;
             _engineHub = engineHub;
+            _taskMaintenanceServiceHealthCheck = taskMaintenanceServiceHealthCheck;
+            _taskMaintenanceServiceHealthCheck.HealthAllowance = _vmTaskProcessingOptions.CurrentValue.HealthCheckTimeoutSeconds > 0 ? _vmTaskProcessingOptions.CurrentValue.HealthCheckTimeoutSeconds : 90;
         }
 
         public STT.Task StartAsync(CancellationToken cancellationToken)
@@ -82,6 +80,7 @@ namespace Steamfitter.Api.Services
                         _logger.LogError("Exception encountered in TaskMaintenanceService Run loop.", ex);
                     }
                     var delaySeconds = _vmTaskProcessingOptions.CurrentValue.ExpirationCheckSeconds > 0 ? _vmTaskProcessingOptions.CurrentValue.ExpirationCheckSeconds : 60;
+                    _taskMaintenanceServiceHealthCheck.CompletedRun();
                     await STT.Task.Delay(new TimeSpan(0, 0, _vmTaskProcessingOptions.CurrentValue.ExpirationCheckSeconds));
                 }
             });

--- a/Steamfitter.Api/Steamfitter.Api.csproj
+++ b/Steamfitter.Api/Steamfitter.Api.csproj
@@ -42,6 +42,10 @@
     <PackageReference Include="Player.Vm.Api.Client" Version="1.5.0" />
     <PackageReference Include="IdentityServer4.AccessTokenValidation" Version="2.7.0" />
     <PackageReference Include="Stackstorm.Connector" Version="1.0.7" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="3.1.0" />
+    <PackageReference Include="AspNetCore.HealthChecks.NpgSql" Version="3.1.0"/>
+    <PackageReference Include="AspNetCore.HealthChecks.SqlServer" Version="3.1.0"/>
+    <PackageReference Include="AspNetCore.HealthChecks.Sqlite" Version="3.1.0"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/Steamfitter.Api/appsettings.json
+++ b/Steamfitter.Api/appsettings.json
@@ -67,6 +67,7 @@
     "ApiBaseUrl": "https://host.docker.internal",
     "VmListUpdateIntervalMinutes": 5,
     "HealthCheckSeconds": 30,
+    "HealthCheckTimeoutSeconds": 90,
     "TaskProcessIntervalMilliseconds": 5000,
     "TaskProcessMaxWaitSeconds": 120,
     "ExpirationCheckSeconds": 30,


### PR DESCRIPTION
## Feature
- Adds `ready` endpoint for startup health
- Adds `live` endpoint for HostedServices health

### Configuration Addition
- Adds **VmTaskProcessing__HealthCheckTimeoutSeconds** appsetting, which defaults to `90`, and is the amount of time, in seconds, that the background timers are allowed to run without checking in before the application is considered `unhealthy