### PR TITLE
change from implicit to auth code

### DIFF
--- a/Steamfitter.Api/Infrastructure/Extensions/ServiceCollectionExtensions.cs
+++ b/Steamfitter.Api/Infrastructure/Extensions/ServiceCollectionExtensions.cs
@@ -36,9 +36,10 @@ namespace Steamfitter.Api.Infrastructure.Extensions
                     Type = SecuritySchemeType.OAuth2,
                     Flows = new OpenApiOAuthFlows
                     {
-                        Implicit = new OpenApiOAuthFlow
+                        AuthorizationCode = new OpenApiOAuthFlow
                         {
                             AuthorizationUrl = new Uri(authOptions.AuthorizationUrl),
+                            TokenUrl = new Uri(authOptions.TokenUrl),
                             Scopes = new Dictionary<string, string>()
                             {
                                 {authOptions.AuthorizationScope, "public api access"}

--- a/Steamfitter.Api/Infrastructure/Options/AuthorizationOptions.cs
+++ b/Steamfitter.Api/Infrastructure/Options/AuthorizationOptions.cs
@@ -7,6 +7,7 @@ namespace Steamfitter.Api.Infrastructure.Options
     {
         public string Authority { get; set; }
         public string AuthorizationUrl { get; set; }
+        public string TokenUrl { get; set; }
         public string AuthorizationScope { get; set; }
         public string ClientId { get; set; }
         public string ClientName { get; set; }

--- a/Steamfitter.Api/Startup.cs
+++ b/Steamfitter.Api/Startup.cs
@@ -251,6 +251,7 @@ namespace Steamfitter.Api
                 c.OAuthClientId(_authOptions.ClientId);
                 c.OAuthClientSecret(_authOptions.ClientSecret);
                 c.OAuthAppName(_authOptions.ClientName);
+                c.OAuthUsePkce();
             });
 
             app.UseAuthentication();

--- a/Steamfitter.Api/appsettings.json
+++ b/Steamfitter.Api/appsettings.json
@@ -35,6 +35,7 @@
   "Authorization": {
     "Authority": "http://host.docker.internal:5000",
     "AuthorizationUrl": "http://host.docker.internal:5000/connect/authorize",
+    "TokenUrl": "http://host.docker.internal:5000/connect/token",
     "AuthorizationScope": "steamfitter player player-vm",
     "ClientId": "steamfitter.swagger",
     "ClientName": "Steamfitter Swagger UI",


### PR DESCRIPTION
### Security Fix

Change OAuth2 flow from `Implicit` to `Authorization Code` to follow best practices.

### Breaking Change
Need to add `TokenUrl` to the IdentityServer's `token` endpoint as an appsetting, and update the Client in Identity.

Addresses internal issue `CRU-1842`.