### PR TITLE
Bugfix/fix initial scenario score

### DIFF
--- a/Steamfitter.Api.Data/SteamfitterContext.cs
+++ b/Steamfitter.Api.Data/SteamfitterContext.cs
@@ -159,11 +159,11 @@ namespace Steamfitter.Api.Data
                 // find value of id property
                 var id = entry.Properties
                     .FirstOrDefault(x =>
-                        x.Metadata.ValueGenerated == Microsoft.EntityFrameworkCore.Metadata.ValueGenerated.OnAdd).CurrentValue;
+                        x.Metadata.ValueGenerated == Microsoft.EntityFrameworkCore.Metadata.ValueGenerated.OnAdd)?.CurrentValue;
 
                 // find matching existing entry, if any
                 var e = Entries.FirstOrDefault(x => x.Properties.FirstOrDefault(y =>
-                    y.Metadata.ValueGenerated == Microsoft.EntityFrameworkCore.Metadata.ValueGenerated.OnAdd).CurrentValue == id);
+                    y.Metadata.ValueGenerated == Microsoft.EntityFrameworkCore.Metadata.ValueGenerated.OnAdd)?.CurrentValue == id);
 
                 if (e != null)
                 {

--- a/Steamfitter.Api.Data/SteamfitterContext.cs
+++ b/Steamfitter.Api.Data/SteamfitterContext.cs
@@ -51,6 +51,13 @@ namespace Steamfitter.Api.Data
 
         public override async Task<int> SaveChangesAsync(CancellationToken ct = default)
         {
+            await CheckForScoreUpdates(ct);
+            SaveEntries();
+            return await base.SaveChangesAsync(ct);
+        }
+
+        private async Task CheckForScoreUpdates(CancellationToken ct)
+        {
             var addedEntries = ChangeTracker.Entries().Where(x => x.State == EntityState.Added).ToList();
             var modifiedEntries = ChangeTracker.Entries().Where(x => x.State == EntityState.Modified).ToList();
             var deletedEntries = ChangeTracker.Entries().Where(x => x.State == EntityState.Deleted).ToList();
@@ -118,6 +125,10 @@ namespace Steamfitter.Api.Data
                 foreach (var scenario in scenarios)
                 {
                     scenario.UpdateScores = true;
+                    Entry(scenario).Properties
+                        .Where(x => x.Metadata.Name == nameof(ScenarioEntity.UpdateScores))
+                        .FirstOrDefault()
+                    .IsModified = true;
                 }
             }
 
@@ -130,12 +141,57 @@ namespace Steamfitter.Api.Data
                 foreach (var scenarioTemplate in scenarioTemplates)
                 {
                     scenarioTemplate.UpdateScores = true;
+                    Entry(scenarioTemplate).Properties
+                        .Where(x => x.Metadata.Name == nameof(ScenarioTemplateEntity.UpdateScores))
+                        .FirstOrDefault()
+                    .IsModified = true;
                 }
             }
+        }
 
-            // keep track of changes across multiple savechanges in a transaction
-            Entries.AddRange(ChangeTracker.Entries().Select(x => new Entry(x)).ToList());
-            return await base.SaveChangesAsync(ct);
+        /// <summary>
+        /// keep track of changes across multiple savechanges in a transaction, without duplicates
+        /// </summary>
+        private void SaveEntries()
+        {
+            foreach (var entry in ChangeTracker.Entries())
+            {
+                // find value of id property
+                var id = entry.Properties
+                    .FirstOrDefault(x =>
+                        x.Metadata.ValueGenerated == Microsoft.EntityFrameworkCore.Metadata.ValueGenerated.OnAdd).CurrentValue;
+
+                // find matching existing entry, if any
+                var e = Entries.FirstOrDefault(x => x.Properties.FirstOrDefault(y =>
+                    y.Metadata.ValueGenerated == Microsoft.EntityFrameworkCore.Metadata.ValueGenerated.OnAdd).CurrentValue == id);
+
+                if (e != null)
+                {
+                    // if entry already exists, mark which properties were previously modified,
+                    // remove old entry and add new one, to avoid duplicates
+                    var modifiedProperties = e.Properties
+                        .Where(x => x.IsModified)
+                        .Select(x => x.Metadata.Name)
+                        .ToArray();
+
+                    var newEntry = new Entry(entry);
+
+                    foreach (var property in newEntry.Properties)
+                    {
+                        if (modifiedProperties.Contains(property.Metadata.Name))
+                        {
+                            property.IsModified = true;
+                        }
+                    }
+
+                    Entries.Remove(e);
+                    Entries.Add(newEntry);
+                }
+                else
+                {
+                    Entries.Add(new Entry(entry));
+                }
+            }
         }
     }
 }

--- a/Steamfitter.Api/Controllers/ScenarioController.cs
+++ b/Steamfitter.Api/Controllers/ScenarioController.cs
@@ -153,14 +153,14 @@ namespace Steamfitter.Api.Controllers
         /// <para />
         /// Accessible only to a SuperUser or an Administrator
         /// </remarks>
-        /// <param name="scenario">The data to create the Scenario with</param>
+        /// <param name="scenarioForm">The data to create the Scenario with</param>
         /// <param name="ct"></param>
         [HttpPost("Scenarios")]
         [ProducesResponseType(typeof(SAVM.Scenario), (int)HttpStatusCode.Created)]
         [SwaggerOperation(OperationId = "createScenario")]
-        public async STT.Task<IActionResult> Create([FromBody] SAVM.Scenario scenario, CancellationToken ct)
+        public async STT.Task<IActionResult> Create([FromBody] SAVM.ScenarioForm scenarioForm, CancellationToken ct)
         {
-            var createdScenario = await _ScenarioService.CreateAsync(scenario, ct);
+            var createdScenario = await _ScenarioService.CreateAsync(scenarioForm, ct);
             return CreatedAtAction(nameof(this.Get), new { id = createdScenario.Id }, createdScenario);
         }
 
@@ -211,14 +211,14 @@ namespace Steamfitter.Api.Controllers
         /// Accessible only to a SuperUser or a User on an Admin Team within the specified Scenario
         /// </remarks>
         /// <param name="id">The Id of the Exericse to update</param>
-        /// <param name="scenario">The updated Scenario values</param>
+        /// <param name="scenarioForm">The updated Scenario values</param>
         /// <param name="ct"></param>
         [HttpPut("Scenarios/{id}")]
         [ProducesResponseType(typeof(SAVM.Scenario), (int)HttpStatusCode.OK)]
         [SwaggerOperation(OperationId = "updateScenario")]
-        public async STT.Task<IActionResult> Update([FromRoute] Guid id, [FromBody] SAVM.Scenario scenario, CancellationToken ct)
+        public async STT.Task<IActionResult> Update([FromRoute] Guid id, [FromBody] SAVM.ScenarioForm scenarioForm, CancellationToken ct)
         {
-            var updatedScenario = await _ScenarioService.UpdateAsync(id, scenario, ct);
+            var updatedScenario = await _ScenarioService.UpdateAsync(id, scenarioForm, ct);
             return Ok(updatedScenario);
         }
 

--- a/Steamfitter.Api/Controllers/ScenarioTemplateController.cs
+++ b/Steamfitter.Api/Controllers/ScenarioTemplateController.cs
@@ -34,7 +34,7 @@ namespace Steamfitter.Api.Controllers
         /// Returns a list of all of the ScenarioTemplates in the system.
         /// <para />
         /// Only accessible to a SuperUser
-        /// </remarks>       
+        /// </remarks>
         /// <returns></returns>
         [HttpGet("scenarioTemplates")]
         [ProducesResponseType(typeof(IEnumerable<SAVM.ScenarioTemplate>), (int)HttpStatusCode.OK)]
@@ -71,7 +71,7 @@ namespace Steamfitter.Api.Controllers
         // /// <para />
         // /// Accessible only to the current User.
         // /// <para/>
-        // /// This is a convenience endpoint and simply returns a 302 redirect to the fully qualified users/{id}/scenarioTemplates endpoint 
+        // /// This is a convenience endpoint and simply returns a 302 redirect to the fully qualified users/{id}/scenarioTemplates endpoint
         // /// </remarks>
         // [HttpGet("me/scenarioTemplates")]
         // [ProducesResponseType(typeof(IEnumerable<ScenarioTemplate>), (int)HttpStatusCode.OK)]
@@ -112,16 +112,15 @@ namespace Steamfitter.Api.Controllers
         /// Creates a new ScenarioTemplate with the attributes specified
         /// <para />
         /// Accessible only to a SuperUser or an Administrator
-        /// </remarks>    
-        /// <param name="scenarioTemplate">The data to create the ScenarioTemplate with</param>
+        /// </remarks>
+        /// <param name="scenarioTemplateForm">The data to create the ScenarioTemplate with</param>
         /// <param name="ct"></param>
         [HttpPost("scenarioTemplates")]
         [ProducesResponseType(typeof(SAVM.ScenarioTemplate), (int)HttpStatusCode.Created)]
         [SwaggerOperation(OperationId = "createScenarioTemplate")]
-        public async STT.Task<IActionResult> Create([FromBody] SAVM.ScenarioTemplate scenarioTemplate, CancellationToken ct)
+        public async STT.Task<IActionResult> Create([FromBody] SAVM.ScenarioTemplateForm scenarioTemplateForm, CancellationToken ct)
         {
-            scenarioTemplate.CreatedBy = User.GetId();
-            var createdScenarioTemplate = await _scenarioTemplateService.CreateAsync(scenarioTemplate, ct);
+            var createdScenarioTemplate = await _scenarioTemplateService.CreateAsync(scenarioTemplateForm, ct);
             return CreatedAtAction(nameof(this.Get), new { id = createdScenarioTemplate.Id }, createdScenarioTemplate);
         }
 
@@ -132,7 +131,7 @@ namespace Steamfitter.Api.Controllers
         /// Copies a new ScenarioTemplate with the attributes specified
         /// <para />
         /// Accessible only to a SuperUser or an Administrator
-        /// </remarks>    
+        /// </remarks>
         /// <param name="id">The ID of scenarioTemplate to copy</param>
         /// <param name="ct"></param>
         [HttpPost("scenarioTemplates/{id}/copy")]
@@ -151,17 +150,16 @@ namespace Steamfitter.Api.Controllers
         /// Updates an ScenarioTemplate with the attributes specified
         /// <para />
         /// Accessible only to a SuperUser or a User on an Admin Team within the specified ScenarioTemplate
-        /// </remarks>  
+        /// </remarks>
         /// <param name="id">The Id of the Exericse to update</param>
-        /// <param name="scenarioTemplate">The updated ScenarioTemplate values</param>
+        /// <param name="scenarioTemplateForm">The updated ScenarioTemplate values</param>
         /// <param name="ct"></param>
         [HttpPut("scenarioTemplates/{id}")]
         [ProducesResponseType(typeof(SAVM.ScenarioTemplate), (int)HttpStatusCode.OK)]
         [SwaggerOperation(OperationId = "updateScenarioTemplate")]
-        public async STT.Task<IActionResult> Update([FromRoute] Guid id, [FromBody] SAVM.ScenarioTemplate scenarioTemplate, CancellationToken ct)
+        public async STT.Task<IActionResult> Update([FromRoute] Guid id, [FromBody] SAVM.ScenarioTemplateForm scenarioTemplateForm, CancellationToken ct)
         {
-            scenarioTemplate.ModifiedBy = User.GetId();
-            var updatedScenarioTemplate = await _scenarioTemplateService.UpdateAsync(id, scenarioTemplate, ct);
+            var updatedScenarioTemplate = await _scenarioTemplateService.UpdateAsync(id, scenarioTemplateForm, ct);
             return Ok(updatedScenarioTemplate);
         }
 
@@ -172,7 +170,7 @@ namespace Steamfitter.Api.Controllers
         /// Deletes an ScenarioTemplate with the specified id
         /// <para />
         /// Accessible only to a SuperUser or a User on an Admin Team within the specified ScenarioTemplate
-        /// </remarks>    
+        /// </remarks>
         /// <param name="id">The id of the ScenarioTemplate to delete</param>
         /// <param name="ct"></param>
         [HttpDelete("scenarioTemplates/{id}")]
@@ -186,4 +184,3 @@ namespace Steamfitter.Api.Controllers
 
     }
 }
-

--- a/Steamfitter.Api/Controllers/TaskController.cs
+++ b/Steamfitter.Api/Controllers/TaskController.cs
@@ -185,14 +185,14 @@ namespace Steamfitter.Api.Controllers
         /// <para />
         /// Accessible only to a SuperUser or an Administrator
         /// </remarks>
-        /// <param name="task">The data to create the Task with</param>
+        /// <param name="taskForm">The data to create the Task with</param>
         /// <param name="ct"></param>
         [HttpPost("Tasks")]
         [ProducesResponseType(typeof(SAVM.Task), (int)HttpStatusCode.Created)]
         [SwaggerOperation(OperationId = "createTask")]
-        public async STT.Task<IActionResult> Create([FromBody] SAVM.Task task, CancellationToken ct)
+        public async STT.Task<IActionResult> Create([FromBody] SAVM.TaskForm taskForm, CancellationToken ct)
         {
-            var createdTask = await _TaskService.CreateAsync(task, ct);
+            var createdTask = await _TaskService.CreateAsync(taskForm, ct);
             return CreatedAtAction(nameof(this.Get), new { id = createdTask.Id }, createdTask);
         }
 
@@ -244,14 +244,14 @@ namespace Steamfitter.Api.Controllers
         /// <para />
         /// Accessible only to a SuperUser or an Administrator
         /// </remarks>
-        /// <param name="task">The data to create the Task with</param>
+        /// <param name="taskForm">The data to create the Task with</param>
         /// <param name="ct"></param>
         [HttpPost("Tasks/execute")]
         [ProducesResponseType(typeof(SAVM.Result[]), (int)HttpStatusCode.Created)]
         [SwaggerOperation(OperationId = "createAndExecuteTask")]
-        public async STT.Task<IActionResult> CreateAndExecute([FromBody] SAVM.Task task, CancellationToken ct)
+        public async STT.Task<IActionResult> CreateAndExecute([FromBody] SAVM.TaskForm taskForm, CancellationToken ct)
         {
-            var resultList = await _TaskService.CreateAndExecuteAsync(task, ct);
+            var resultList = await _TaskService.CreateAndExecuteAsync(taskForm, ct);
             return Ok(resultList);
         }
 
@@ -295,11 +295,11 @@ namespace Steamfitter.Api.Controllers
         {
             var executionTime = DateTime.UtcNow;
             var gradedTaskId = await _TaskService.ExecuteForGradeAsync(gradedExecutionInfo, ct);
-            var result = new GradeCheckInfo ()
-                {
-                    GradedTaskId = (Guid)gradedTaskId,
-                    ExecutionStartTime = executionTime
-                };
+            var result = new GradeCheckInfo()
+            {
+                GradedTaskId = (Guid)gradedTaskId,
+                ExecutionStartTime = executionTime
+            };
             return Ok(result);
         }
 
@@ -312,14 +312,14 @@ namespace Steamfitter.Api.Controllers
         /// Accessible only to a SuperUser or a User on an Admin Team within the specified Task
         /// </remarks>
         /// <param name="id">The Id of the Exericse to update</param>
-        /// <param name="task">The updated Task values</param>
+        /// <param name="taskForm">The updated Task values</param>
         /// <param name="ct"></param>
         [HttpPut("Tasks/{id}")]
         [ProducesResponseType(typeof(SAVM.Task), (int)HttpStatusCode.OK)]
         [SwaggerOperation(OperationId = "updateTask")]
-        public async STT.Task<IActionResult> Update([FromRoute] Guid id, [FromBody] SAVM.Task task, CancellationToken ct)
+        public async STT.Task<IActionResult> Update([FromRoute] Guid id, [FromBody] SAVM.TaskForm taskForm, CancellationToken ct)
         {
-            var updatedTask = await _TaskService.UpdateAsync(id, task, ct);
+            var updatedTask = await _TaskService.UpdateAsync(id, taskForm, ct);
             return Ok(updatedTask);
         }
 

--- a/Steamfitter.Api/Infrastructure/Mappings/ScenarioProfile.cs
+++ b/Steamfitter.Api/Infrastructure/Mappings/ScenarioProfile.cs
@@ -22,12 +22,12 @@ namespace Steamfitter.Api.Infrastructure.Mappings
             CreateMap<ScenarioEntity, Scenario>()
                 .ForMember(m => m.Users, opt => opt.MapFrom(x => x.Users.Select(y => y.UserId)));
 
-            CreateMap<Scenario, ScenarioEntity>()
-                .ForMember(m => m.Users, opt => opt.Ignore());
+            CreateMap<Scenario, ScenarioEntity>();
 
             CreateMap<ScenarioEntity, ScenarioEntity>()
                 .ForMember(e => e.Id, opt => opt.Ignore());
 
+            CreateMap<ScenarioForm, ScenarioEntity>();
         }
     }
 }

--- a/Steamfitter.Api/Infrastructure/Mappings/ScenarioTemplateProfile.cs
+++ b/Steamfitter.Api/Infrastructure/Mappings/ScenarioTemplateProfile.cs
@@ -23,8 +23,7 @@ namespace Steamfitter.Api.Infrastructure.Mappings
             CreateMap<ScenarioTemplateEntity, ScenarioTemplateEntity>()
                 .ForMember(e => e.Id, opt => opt.Ignore());
 
+            CreateMap<ScenarioTemplateForm, ScenarioTemplateEntity>();
         }
     }
 }
-
-

--- a/Steamfitter.Api/Infrastructure/Mappings/TaskProfile.cs
+++ b/Steamfitter.Api/Infrastructure/Mappings/TaskProfile.cs
@@ -23,6 +23,8 @@ namespace Steamfitter.Api.Infrastructure.Mappings
 
             CreateMap<TaskEntity, TaskEntity>()
                 .ForMember(dt => dt.Id, opt => opt.Ignore());
+
+            CreateMap<TaskForm, TaskEntity>();
         }
 
         private Dictionary<string, string> ConvertToActionParameters(TaskEntity src)

--- a/Steamfitter.Api/Services/ScenarioService.cs
+++ b/Steamfitter.Api/Services/ScenarioService.cs
@@ -28,10 +28,10 @@ namespace Steamfitter.Api.Services
         STT.Task<IEnumerable<ViewModels.Scenario>> GetByViewIdAsync(Guid viewId, CancellationToken ct);
         STT.Task<ViewModels.Scenario> GetAsync(Guid Id, CancellationToken ct);
         STT.Task<ViewModels.Scenario> GetMineAsync(CancellationToken ct);
-        STT.Task<ViewModels.Scenario> CreateAsync(ViewModels.Scenario Scenario, CancellationToken ct);
+        STT.Task<ViewModels.Scenario> CreateAsync(ViewModels.ScenarioForm scenarioForm, CancellationToken ct);
         STT.Task<ViewModels.Scenario> CreateFromScenarioTemplateAsync(Guid scenarioTemplateId, CancellationToken ct);
         STT.Task<ViewModels.Scenario> CreateFromScenarioAsync(Guid scenarioId, CancellationToken ct);
-        STT.Task<ViewModels.Scenario> UpdateAsync(Guid Id, ViewModels.Scenario Scenario, CancellationToken ct);
+        STT.Task<ViewModels.Scenario> UpdateAsync(Guid Id, ViewModels.ScenarioForm scenarioForm, CancellationToken ct);
         STT.Task<ViewModels.Scenario> AddUsersAsync(Guid Id, IEnumerable<Guid> userIds, CancellationToken ct);
         STT.Task<bool> DeleteAsync(Guid Id, CancellationToken ct);
         STT.Task<ViewModels.Scenario> StartAsync(Guid Id, CancellationToken ct);
@@ -149,14 +149,14 @@ namespace Steamfitter.Api.Services
             return _mapper.Map<SAVM.Scenario>(item);
         }
 
-        public async STT.Task<ViewModels.Scenario> CreateAsync(ViewModels.Scenario scenario, CancellationToken ct)
+        public async STT.Task<ViewModels.Scenario> CreateAsync(ViewModels.ScenarioForm scenarioForm, CancellationToken ct)
         {
             if (!(await _authorizationService.AuthorizeAsync(_user, null, new ContentDeveloperRequirement())).Succeeded)
                 throw new ForbiddenException();
 
-            scenario.DateCreated = DateTime.UtcNow;
-            scenario.CreatedBy = _user.GetId();
-            var scenarioEntity = _mapper.Map<ScenarioEntity>(scenario);
+            var scenarioEntity = _mapper.Map<ScenarioEntity>(scenarioForm);
+            scenarioEntity.DateCreated = DateTime.UtcNow;
+            scenarioEntity.CreatedBy = _user.GetId();
 
             //TODO: add permissions
             // var ScenarioAdminPermission = await _context.Permissions
@@ -168,7 +168,7 @@ namespace Steamfitter.Api.Services
 
             _context.Scenarios.Add(scenarioEntity);
             await _context.SaveChangesAsync(ct);
-            scenario = await GetAsync(scenarioEntity.Id, ct);
+            var scenario = await GetAsync(scenarioEntity.Id, ct);
 
             return scenario;
         }
@@ -247,7 +247,7 @@ namespace Steamfitter.Api.Services
             return scenario;
         }
 
-        public async STT.Task<ViewModels.Scenario> UpdateAsync(Guid id, ViewModels.Scenario scenario, CancellationToken ct)
+        public async STT.Task<SAVM.Scenario> UpdateAsync(Guid id, ViewModels.ScenarioForm scenarioForm, CancellationToken ct)
         {
             if (!(await _authorizationService.AuthorizeAsync(_user, null, new ContentDeveloperRequirement())).Succeeded)
                 throw new ForbiddenException();
@@ -257,17 +257,13 @@ namespace Steamfitter.Api.Services
             if (scenarioToUpdate == null)
                 throw new EntityNotFoundException<SAVM.Scenario>();
 
-            scenario.DateCreated = scenarioToUpdate.DateCreated;
-            scenario.CreatedBy = scenarioToUpdate.CreatedBy;
-            scenario.DateModified = DateTime.UtcNow;
-            scenario.ModifiedBy = _user.GetId();
-            _mapper.Map(scenario, scenarioToUpdate);
+            _mapper.Map(scenarioForm, scenarioToUpdate);
+            scenarioToUpdate.DateModified = DateTime.UtcNow;
+            scenarioToUpdate.ModifiedBy = _user.GetId();
 
-            _context.Scenarios.Update(scenarioToUpdate);
             await _context.SaveChangesAsync(ct);
 
-            var updatedScenario = _mapper.Map(scenarioToUpdate, scenario);
-
+            var updatedScenario = _mapper.Map<SAVM.Scenario>(scenarioToUpdate);
             return updatedScenario;
         }
 
@@ -310,7 +306,6 @@ namespace Steamfitter.Api.Services
             scenarioToUpdate.ModifiedBy = _user.GetId();
             scenarioToUpdate.AddUsers(userIds);
 
-            _context.Scenarios.Update(scenarioToUpdate);
             await _context.SaveChangesAsync(ct);
 
             var updatedScenario = _mapper.Map<SAVM.Scenario>(scenarioToUpdate);
@@ -347,7 +342,6 @@ namespace Steamfitter.Api.Services
             scenario.StartDate = dateTimeStart;
             scenario.Status = ScenarioStatus.active;
 
-            _context.Scenarios.Update(scenario);
             await _context.SaveChangesAsync(ct);
             // TODO:  create a better way to do this that doesn't require getting ALL of the VM's
             // We just need to grab all of the VM's from the scenario view
@@ -389,7 +383,6 @@ namespace Steamfitter.Api.Services
             scenario.Status = ScenarioStatus.ended;
             scenario.EndDate = endDateTime;
 
-            _context.Scenarios.Update(scenario);
             await _context.SaveChangesAsync(ct);
 
             var updatedScenario = _mapper.Map<SAVM.Scenario>(scenario);

--- a/Steamfitter.Api/Services/ScenarioTemplateService.cs
+++ b/Steamfitter.Api/Services/ScenarioTemplateService.cs
@@ -110,6 +110,7 @@ namespace Steamfitter.Api.Services
             if (!(await _authorizationService.AuthorizeAsync(_user, null, new ContentDeveloperRequirement())).Succeeded)
                 throw new ForbiddenException();
 
+            await using var transaction = await _context.Database.BeginTransactionAsync(ct);
             var oldScenarioTemplateEntity = _context.ScenarioTemplates.Find(oldScenarioTemplateId);
             if (oldScenarioTemplateEntity == null)
                 throw new EntityNotFoundException<SAVM.ScenarioTemplate>($"ScenarioTemplate {oldScenarioTemplateId} was not found.");
@@ -134,6 +135,7 @@ namespace Steamfitter.Api.Services
                 await _taskService.CopyAsync(oldTaskEntityId, newScenarioTemplateEntity.Id, "scenarioTemplate", ct);
             }
 
+            await transaction.CommitAsync(ct);
             var newScenarioTemplate = await GetAsync(newScenarioTemplateEntity.Id, ct);
 
             return newScenarioTemplate;

--- a/Steamfitter.Api/Services/ScenarioTemplateService.cs
+++ b/Steamfitter.Api/Services/ScenarioTemplateService.cs
@@ -28,9 +28,9 @@ namespace Steamfitter.Api.Services
         STT.Task<IEnumerable<ViewModels.ScenarioTemplate>> GetAsync(CancellationToken ct);
         STT.Task<ViewModels.ScenarioTemplate> GetAsync(Guid id, CancellationToken ct);
         // STT.Task<IEnumerable<ViewModels.ScenarioTemplate>> GetByUserIdAsync(Guid userId, CancellationToken ct);
-        STT.Task<ViewModels.ScenarioTemplate> CreateAsync(ViewModels.ScenarioTemplate scenarioTemplate, CancellationToken ct);
+        STT.Task<ViewModels.ScenarioTemplate> CreateAsync(ViewModels.ScenarioTemplateForm scenarioTemplateForm, CancellationToken ct);
         STT.Task<ViewModels.ScenarioTemplate> CopyAsync(Guid id, CancellationToken ct);
-        STT.Task<ViewModels.ScenarioTemplate> UpdateAsync(Guid id, ViewModels.ScenarioTemplate scenarioTemplate, CancellationToken ct);
+        STT.Task<ViewModels.ScenarioTemplate> UpdateAsync(Guid id, ViewModels.ScenarioTemplateForm scenarioTemplateForm, CancellationToken ct);
         STT.Task<bool> DeleteAsync(Guid id, CancellationToken ct);
     }
 
@@ -81,13 +81,14 @@ namespace Steamfitter.Api.Services
             return _mapper.Map<SAVM.ScenarioTemplate>(item);
         }
 
-        public async STT.Task<ViewModels.ScenarioTemplate> CreateAsync(ViewModels.ScenarioTemplate scenarioTemplate, CancellationToken ct)
+        public async STT.Task<ViewModels.ScenarioTemplate> CreateAsync(ViewModels.ScenarioTemplateForm scenarioTemplateForm, CancellationToken ct)
         {
             if (!(await _authorizationService.AuthorizeAsync(_user, null, new ContentDeveloperRequirement())).Succeeded)
                 throw new ForbiddenException();
 
-            scenarioTemplate.DateCreated = DateTime.UtcNow;
-            var scenarioTemplateEntity = _mapper.Map<ScenarioTemplateEntity>(scenarioTemplate);
+            var scenarioTemplateEntity = _mapper.Map<ScenarioTemplateEntity>(scenarioTemplateForm);
+            scenarioTemplateEntity.DateCreated = DateTime.UtcNow;
+            scenarioTemplateEntity.CreatedBy = _user.GetId();
 
             //TODO: add permissions
             // var scenarioTemplateAdminPermission = await _context.Permissions
@@ -99,7 +100,7 @@ namespace Steamfitter.Api.Services
 
             _context.ScenarioTemplates.Add(scenarioTemplateEntity);
             await _context.SaveChangesAsync(ct);
-            scenarioTemplate = await GetAsync(scenarioTemplateEntity.Id, ct);
+            var scenarioTemplate = await GetAsync(scenarioTemplateEntity.Id, ct);
 
             return scenarioTemplate;
         }
@@ -138,7 +139,7 @@ namespace Steamfitter.Api.Services
             return newScenarioTemplate;
         }
 
-        public async STT.Task<ViewModels.ScenarioTemplate> UpdateAsync(Guid id, ViewModels.ScenarioTemplate scenarioTemplate, CancellationToken ct)
+        public async STT.Task<ViewModels.ScenarioTemplate> UpdateAsync(Guid id, ViewModels.ScenarioTemplateForm scenarioTemplateForm, CancellationToken ct)
         {
             if (!(await _authorizationService.AuthorizeAsync(_user, null, new ContentDeveloperRequirement())).Succeeded)
                 throw new ForbiddenException();
@@ -148,15 +149,14 @@ namespace Steamfitter.Api.Services
             if (scenarioTemplateToUpdate == null)
                 throw new EntityNotFoundException<SAVM.ScenarioTemplate>();
 
-            scenarioTemplate.CreatedBy = scenarioTemplateToUpdate.CreatedBy;
-            scenarioTemplate.DateCreated = scenarioTemplateToUpdate.DateCreated;
-            scenarioTemplate.DateModified = DateTime.UtcNow;
-            _mapper.Map(scenarioTemplate, scenarioTemplateToUpdate);
+            _mapper.Map(scenarioTemplateForm, scenarioTemplateToUpdate);
+            scenarioTemplateToUpdate.DateModified = DateTime.UtcNow;
+            scenarioTemplateToUpdate.ModifiedBy = _user.GetId();
 
             _context.ScenarioTemplates.Update(scenarioTemplateToUpdate);
             await _context.SaveChangesAsync(ct);
 
-            scenarioTemplate = await GetAsync(scenarioTemplateToUpdate.Id, ct);
+            var scenarioTemplate = await GetAsync(scenarioTemplateToUpdate.Id, ct);
 
             return scenarioTemplate;
         }

--- a/Steamfitter.Api/Services/ScoringService.cs
+++ b/Steamfitter.Api/Services/ScoringService.cs
@@ -54,7 +54,7 @@ namespace Steamfitter.Api.Services
 
                 // create serializable transaction to prevent multiple scores from being changed concurrently,
                 // causing incorrect total score calculations
-                using var transaction = await db.Database.BeginTransactionAsync(IsolationLevel.Serializable);
+                await using var transaction = await db.Database.BeginTransactionAsync(IsolationLevel.Serializable);
 
                 // get all tasks in scenario or scenario template
                 if (type == typeof(ScenarioEntity))

--- a/Steamfitter.Api/Services/TaskService.cs
+++ b/Steamfitter.Api/Services/TaskService.cs
@@ -297,7 +297,7 @@ namespace Steamfitter.Api.Services
 
                 // create serializable transaction to prevent multiple scores from being changed concurrently,
                 // causing incorrect total score calculations
-                using var transaction = await dbContext.Database.BeginTransactionAsync(IsolationLevel.Serializable);
+                await using var transaction = await dbContext.Database.BeginTransactionAsync(IsolationLevel.Serializable);
 
                 taskToExecute = await dbContext.Tasks
                     .Include(x => x.Scenario)
@@ -432,6 +432,7 @@ namespace Steamfitter.Api.Services
             // check user authorization
             if (!(await _authorizationService.AuthorizeAsync(_user, null, new ContentDeveloperRequirement())).Succeeded)
                 throw new ForbiddenException();
+
             var items = await CopyTaskAsync(id, newLocationId, newLocationType, ct);
 
             return _mapper.Map<IEnumerable<SAVM.Task>>(items);
@@ -442,6 +443,7 @@ namespace Steamfitter.Api.Services
             // check user authorization
             if (!(await _authorizationService.AuthorizeAsync(_user, null, new ContentDeveloperRequirement())).Succeeded)
                 throw new ForbiddenException();
+
             var items = await MoveTaskAsync(id, newLocationId, newLocationType, ct);
 
             return _mapper.Map<IEnumerable<SAVM.Task>>(items);

--- a/Steamfitter.Api/ViewModels/Scenario.cs
+++ b/Steamfitter.Api/ViewModels/Scenario.cs
@@ -7,16 +7,7 @@ using System.Collections.Generic;
 
 namespace Steamfitter.Api.ViewModels
 {
-    public interface IScenario
-    {
-        Guid Id { get; set; }
-        string Name { get; set; }
-        int Score { get; set; }
-        int ScoreEarned { get; set; }
-        Guid? ViewId { get; set; }
-    }
-
-    public class Scenario : Base, IScenario
+    public class Scenario : Base
     {
         public Guid Id { get; set; }
         public string Name { get; set; }
@@ -35,12 +26,31 @@ namespace Steamfitter.Api.ViewModels
         public int ScoreEarned { get; set; }
     }
 
-    public class ScenarioSummary : IScenario
+    /// <summary>
+    /// Returned to unprivileged users
+    /// </summary>
+    public class ScenarioSummary : Base
     {
         public Guid Id { get; set; }
         public string Name { get; set; }
         public int Score { get; set; }
         public int ScoreEarned { get; set; }
         public Guid? ViewId { get; set; }
+    }
+
+
+    public class ScenarioForm
+    {
+        public string Name { get; set; }
+        public string Description { get; set; }
+        public DateTime StartDate { get; set; }
+        public DateTime EndDate { get; set; }
+        public ScenarioStatus Status { get; set; }
+        public bool OnDemand { get; set; }
+        public Guid? ScenarioTemplateId { get; set; }
+        public Guid? ViewId { get; set; }
+        public string View { get; set; }
+        public Guid? DefaultVmCredentialId { get; set; }
+        public List<VmCredential> VmCredentials { get; set; }
     }
 }

--- a/Steamfitter.Api/ViewModels/ScenarioTemplate.cs
+++ b/Steamfitter.Api/ViewModels/ScenarioTemplate.cs
@@ -17,4 +17,13 @@ namespace Steamfitter.Api.ViewModels
         public int Score { get; set; }
         public int ScoreEarned { get; set; }
     }
+
+    public class ScenarioTemplateForm
+    {
+        public string Name { get; set; }
+        public string Description { get; set; }
+        public int? DurationHours { get; set; }
+        public Guid? DefaultVmCredentialId { get; set; }
+        public List<VmCredential> VmCredentials { get; set; }
+    }
 }

--- a/Steamfitter.Api/ViewModels/Task.cs
+++ b/Steamfitter.Api/ViewModels/Task.cs
@@ -7,40 +7,6 @@ using System.Collections.Generic;
 
 namespace Steamfitter.Api.ViewModels
 {
-    public interface ITask
-    {
-        Guid Id { get; set; }
-        string Name { get; set; }
-        int Score { get; set; }
-        int ScoreEarned { get; set; }
-        TaskStatus Status { get; set; }
-        string Description { get; set; }
-        Guid? ScenarioId { get; set; }
-        bool UserExecutable { get; set; }
-        int TotalScore { get; set; }
-        int TotalScoreEarned { get; set; }
-        TaskStatus TotalStatus { get; set; }
-        bool Repeatable { get; set; }
-        bool Executable { get; set; }
-    }
-
-    public class TaskSummary : Base, ITask
-    {
-        public Guid Id { get; set; }
-        public string Name { get; set; }
-        public int Score { get; set; }
-        public int ScoreEarned { get; set; }
-        public TaskStatus Status { get; set; }
-        public string Description { get; set; }
-        public Guid? ScenarioId { get; set; }
-        public bool UserExecutable { get; set; }
-        public int TotalScore { get; set; }
-        public int TotalScoreEarned { get; set; }
-        public TaskStatus TotalStatus { get; set; }
-        public bool Repeatable { get; set; }
-        public bool Executable { get; set; }
-    }
-
     public class Task : Base
     {
         public Guid Id { get; set; }
@@ -70,6 +36,50 @@ namespace Steamfitter.Api.ViewModels
         public int TotalScore { get; set; }
         public int TotalScoreEarned { get; set; }
         public TaskStatus TotalStatus { get; set; }
+        public bool Repeatable { get; set; }
+        public bool Executable { get; set; }
+    }
+
+    public class TaskSummary : Base
+    {
+        public Guid Id { get; set; }
+        public string Name { get; set; }
+        public int Score { get; set; }
+        public int ScoreEarned { get; set; }
+        public TaskStatus Status { get; set; }
+        public string Description { get; set; }
+        public Guid? ScenarioId { get; set; }
+        public bool UserExecutable { get; set; }
+        public int TotalScore { get; set; }
+        public int TotalScoreEarned { get; set; }
+        public TaskStatus TotalStatus { get; set; }
+        public bool Repeatable { get; set; }
+        public bool Executable { get; set; }
+    }
+
+    public class TaskForm
+    {
+        public string Name { get; set; }
+        public string Description { get; set; }
+        public Guid? ScenarioTemplateId { get; set; }
+        public Guid? ScenarioId { get; set; }
+        public Guid? UserId { get; set; }
+        public TaskAction Action { get; set; }
+        public string VmMask { get; set; }
+        public List<Guid> VmList { get; set; }
+        public string ApiUrl { get; set; }
+        public Dictionary<string, string> ActionParameters { get; set; }
+        public string ExpectedOutput { get; set; }
+        public int ExpirationSeconds { get; set; }
+        public int DelaySeconds { get; set; }
+        public int IntervalSeconds { get; set; }
+        public int Iterations { get; set; }
+        public TaskIterationTermination IterationTermination { get; set; }
+        public int CurrentIteration { get; set; }
+        public Guid? TriggerTaskId { get; set; }
+        public TaskTrigger TriggerCondition { get; set; }
+        public int Score { get; set; }
+        public bool UserExecutable { get; set; }
         public bool Repeatable { get; set; }
         public bool Executable { get; set; }
     }


### PR DESCRIPTION
fixed initial scenario score sometimes being erroneously set to 0
- set isModified = true on Scenario UpdateScores property in CheckForScoreUpdates
- consolidate duplicate change entries in SaveChanges
- added separate form classes for creating/editing scenarios, scenarioTemplates, and tasks
  - forms do not contain properties that should not be edited externally like score and status rollups
  
added transaction to some methods

- avoid duplicate events of partially completed actions
- avoid partial results in case of errors