### PR TITLE
Add UserAccess Requirement similar to Player

### DIFF
--- a/Steamfitter.Api/Infrastructure/Authorization/UserAccessRequirement.cs
+++ b/Steamfitter.Api/Infrastructure/Authorization/UserAccessRequirement.cs
@@ -1,0 +1,39 @@
+// Copyright 2021 Carnegie Mellon University. All Rights Reserved.
+// Released under a MIT (SEI)-style license. See LICENSE.md in the project root for license information.
+
+using Microsoft.AspNetCore.Authorization;
+using System.Security.Claims;
+using STT = System.Threading.Tasks;
+using System;
+using Steamfitter.Api.Infrastructure.Extensions;
+
+namespace Steamfitter.Api.Infrastructure.Authorization
+{
+    public class UserAccessRequirement : IAuthorizationRequirement
+    {
+        public Guid UserId { get; set; }
+
+        public UserAccessRequirement(Guid userId)
+        {
+            UserId = userId;
+        }
+    }
+
+    public class UserAccessHandler : AuthorizationHandler<UserAccessRequirement>, IAuthorizationHandler
+    {
+        protected override STT.Task HandleRequirementAsync(AuthorizationHandlerContext context, UserAccessRequirement requirement)
+        {
+            if(context.User.HasClaim(c => c.Type == SteamfitterClaimTypes.SystemAdmin.ToString()))
+            {
+                context.Succeed(requirement);
+            }
+            else if (context.User.GetId() == requirement.UserId)
+            {
+                context.Succeed(requirement);
+            }
+
+            return STT.Task.CompletedTask;
+        }
+    }
+}
+

--- a/Steamfitter.Api/Infrastructure/Extensions/AuthorizationPolicyExtension.cs
+++ b/Steamfitter.Api/Infrastructure/Extensions/AuthorizationPolicyExtension.cs
@@ -15,6 +15,7 @@ namespace Steamfitter.Api.Infrastructure.Extensions
             services.AddSingleton<IAuthorizationHandler, FullRightsHandler>();
             services.AddSingleton<IAuthorizationHandler, ContentDeveloperHandler>();
             services.AddSingleton<IAuthorizationHandler, OperatorHandler>();
+            services.AddSingleton<IAuthorizationHandler, UserAccessHandler>();
             services.AddSingleton<IAuthorizationHandler, BaseUserHandler>();
         }
 

--- a/Steamfitter.Api/Services/UserService.cs
+++ b/Steamfitter.Api/Services/UserService.cs
@@ -60,7 +60,7 @@ namespace Steamfitter.Api.Services
 
         public async STT.Task<ViewModels.User> GetAsync(Guid id, CancellationToken ct)
         {
-            if (!(await _authorizationService.AuthorizeAsync(_user, null, new FullRightsRequirement())).Succeeded)
+            if (!(await _authorizationService.AuthorizeAsync(_user, null, new UserAccessRequirement(id))).Succeeded)
                 throw new ForbiddenException();
 
             var item = await _context.Users


### PR DESCRIPTION
Previously, when a user called `/api/users/{id}`, the authentication was requiring that user be `SystemAdmin` to proceed.  This endpoint gets called when setting the logged-in user in Steamfitter, rendering the app unusable to non-`SystemAdmin`.

This PR changes the authentication to match `/api/users/{id}` in Player ([here](https://github.com/cmu-sei/Player.Api/blob/development/Player.Api/Services/UserService.cs), [here](https://github.com/cmu-sei/Player.Api/blob/development/Player.Api/Infrastructure/Authorization/UserAccess.cs)) such that a new `UserAccessRequirement` has been created to allow both all `SystemAdmin`s and the calling user to call the `/api/users/{id}` on themselves.

Handles internal ticket `CRU-1854`.