### PR TITLE
Feature/scenario create options

### DIFF
--- a/Steamfitter.Api/Controllers/ScenarioController.cs
+++ b/Steamfitter.Api/Controllers/ScenarioController.cs
@@ -12,6 +12,7 @@ using Steamfitter.Api.Infrastructure.Exceptions;
 using Steamfitter.Api.Services;
 using SAVM = Steamfitter.Api.ViewModels;
 using Swashbuckle.AspNetCore.Annotations;
+using Steamfitter.Api.ViewModels;
 
 namespace Steamfitter.Api.Controllers
 {
@@ -173,13 +174,14 @@ namespace Steamfitter.Api.Controllers
         /// Accessible only to a SuperUser or an Administrator
         /// </remarks>
         /// <param name="id">The ScenarioTemplate ID to create the Scenario with</param>
+        /// <param name="options"></param>
         /// <param name="ct"></param>
         [HttpPost("ScenarioTemplates/{id}/Scenarios")]
         [ProducesResponseType(typeof(SAVM.Scenario), (int)HttpStatusCode.Created)]
         [SwaggerOperation(OperationId = "createScenarioFromScenarioTemplate")]
-        public async STT.Task<IActionResult> CreateFromScenarioTemplate(Guid id, CancellationToken ct)
+        public async STT.Task<IActionResult> CreateFromScenarioTemplate(Guid id, [FromBody] ScenarioCloneOptions options, CancellationToken ct)
         {
-            var createdScenario = await _ScenarioService.CreateFromScenarioTemplateAsync(id, ct);
+            var createdScenario = await _ScenarioService.CreateFromScenarioTemplateAsync(id, options, ct);
             return CreatedAtAction(nameof(this.Get), new { id = createdScenario.Id }, createdScenario);
         }
 

--- a/Steamfitter.Api/Startup.cs
+++ b/Steamfitter.Api/Startup.cs
@@ -149,7 +149,6 @@ namespace Steamfitter.Api
             .AddJsonOptions(options =>
             {
                 options.JsonSerializerOptions.Converters.Add(new JsonNullableGuidConverter());
-                options.JsonSerializerOptions.Converters.Add(new JsonIntegerConverter());
                 options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
             })
             .SetCompatibilityVersion(CompatibilityVersion.Latest);

--- a/Steamfitter.Api/ViewModels/Scenario.cs
+++ b/Steamfitter.Api/ViewModels/Scenario.cs
@@ -53,4 +53,11 @@ namespace Steamfitter.Api.ViewModels
         public Guid? DefaultVmCredentialId { get; set; }
         public List<VmCredential> VmCredentials { get; set; }
     }
+
+    public class ScenarioCloneOptions
+    {
+        public string NameSuffix { get; set; }
+        public Guid? ViewId { get; set; }
+        public List<Guid> UserIds { get; set; }
+    }
 }


### PR DESCRIPTION
- added options to CreateFromScenarioTemplate endpoint
  - allows for setting common properties while cloning to avoid multiple calls
- remove JsonIntegerConverter
  - handle sending proper json integers at the ui instead