### PR TITLE
improve support for different identity providers

### DIFF
--- a/Steamfitter.Api/Infrastructure/Authorization/AuthorizationClaimsTransformer.cs
+++ b/Steamfitter.Api/Infrastructure/Authorization/AuthorizationClaimsTransformer.cs
@@ -5,11 +5,12 @@ using System.Security.Claims;
 using STT = System.Threading.Tasks;
 using Steamfitter.Api.Services;
 using Microsoft.AspNetCore.Authentication;
+using Steamfitter.Api.Infrastructure.Extensions;
 
 namespace Steamfitter.Api.Infrastructure.Authorization
 {
     class AuthorizationClaimsTransformer : IClaimsTransformation
-    {        
+    {
         private IUserClaimsService _claimsService;
 
         public AuthorizationClaimsTransformer(IUserClaimsService claimsService)
@@ -19,10 +20,11 @@ namespace Steamfitter.Api.Infrastructure.Authorization
 
         public async STT.Task<ClaimsPrincipal> TransformAsync(ClaimsPrincipal principal)
         {
-            var user = await _claimsService.AddUserClaims(principal, true);
+            var user = principal.NormalizeScopeClaims();
+            user = await _claimsService.AddUserClaims(user, true);
             _claimsService.SetCurrentClaimsPrincipal(user);
             return user;
-        }       
+        }
     }
 }
 

--- a/Steamfitter.Api/Infrastructure/Extensions/AuthorizationPolicyExtension.cs
+++ b/Steamfitter.Api/Infrastructure/Extensions/AuthorizationPolicyExtension.cs
@@ -1,6 +1,7 @@
 // Copyright 2021 Carnegie Mellon University. All Rights Reserved.
 // Released under a MIT (SEI)-style license. See LICENSE.md in the project root for license information.
 
+using System;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.Extensions.DependencyInjection;
 using Steamfitter.Api.Infrastructure.Authorization;
@@ -9,9 +10,17 @@ namespace Steamfitter.Api.Infrastructure.Extensions
 {
     public static class AuthorizationPolicyExtensions
     {
-        public static void AddAuthorizationPolicy(this IServiceCollection services)
+        public static void AddAuthorizationPolicy(this IServiceCollection services, Options.AuthorizationOptions authOptions)
         {
-            services.AddAuthorization();
+            services.AddAuthorization(options =>
+            {
+                // Require all scopes in authOptions
+                var policyBuilder = new AuthorizationPolicyBuilder().RequireAuthenticatedUser();
+                Array.ForEach(authOptions.AuthorizationScope.Split(' '), x => policyBuilder.RequireClaim("scope", x));
+
+                options.DefaultPolicy = policyBuilder.Build();
+            });
+
             services.AddSingleton<IAuthorizationHandler, FullRightsHandler>();
             services.AddSingleton<IAuthorizationHandler, ContentDeveloperHandler>();
             services.AddSingleton<IAuthorizationHandler, OperatorHandler>();

--- a/Steamfitter.Api/Infrastructure/Extensions/ClaimsPrincipalExtensions.cs
+++ b/Steamfitter.Api/Infrastructure/Extensions/ClaimsPrincipalExtensions.cs
@@ -3,6 +3,7 @@
 
 
 using System;
+using System.Collections.Generic;
 using System.Security.Claims;
 
 namespace Steamfitter.Api.Infrastructure.Extensions
@@ -20,6 +21,47 @@ namespace Steamfitter.Api.Infrastructure.Extensions
             {
                 return Guid.Parse(principal.FindFirst(@"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier")?.Value);
             }
+        }
+
+        /// <summary>
+        /// Normalize scope claims to handle array or single string
+        /// </summary>
+        public static ClaimsPrincipal NormalizeScopeClaims(this ClaimsPrincipal principal)
+        {
+            var identities = new List<ClaimsIdentity>();
+
+            foreach (var id in principal.Identities)
+            {
+                var identity = new ClaimsIdentity(id.AuthenticationType, id.NameClaimType, id.RoleClaimType);
+
+                foreach (var claim in id.Claims)
+                {
+                    if (claim.Type == "scope")
+                    {
+                        if (claim.Value.Contains(' '))
+                        {
+                            var scopes = claim.Value.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+
+                            foreach (var scope in scopes)
+                            {
+                                identity.AddClaim(new Claim("scope", scope, claim.ValueType, claim.Issuer));
+                            }
+                        }
+                        else
+                        {
+                            identity.AddClaim(claim);
+                        }
+                    }
+                    else
+                    {
+                        identity.AddClaim(claim);
+                    }
+                }
+
+                identities.Add(identity);
+            }
+
+            return new ClaimsPrincipal(identities);
         }
     }
 }

--- a/Steamfitter.Api/Infrastructure/Options/AuthorizationOptions.cs
+++ b/Steamfitter.Api/Infrastructure/Options/AuthorizationOptions.cs
@@ -13,6 +13,8 @@ namespace Steamfitter.Api.Infrastructure.Options
         public string ClientName { get; set; }
         public string ClientSecret { get; set; }
         public bool RequireHttpsMetadata { get; set; }
+        public bool ValidateAudience { get; set; }
+        public string[] ValidAudiences { get; set; }
     }
 }
 

--- a/Steamfitter.Api/Startup.cs
+++ b/Steamfitter.Api/Startup.cs
@@ -166,10 +166,22 @@ namespace Steamfitter.Api
                 options.Authority = _authOptions.Authority;
                 options.RequireHttpsMetadata = _authOptions.RequireHttpsMetadata;
                 options.SaveToken = true;
+
+                string[] validAudiences;
+
+                if (_authOptions.ValidAudiences != null && _authOptions.ValidAudiences.Any())
+                {
+                    validAudiences = _authOptions.ValidAudiences;
+                }
+                else
+                {
+                    validAudiences = _authOptions.AuthorizationScope.Split(' ');
+                }
+
                 options.TokenValidationParameters = new Microsoft.IdentityModel.Tokens.TokenValidationParameters
                 {
-                    ValidateIssuer = true,
-                    ValidAudiences = _authOptions.AuthorizationScope.Split(' ')
+                    ValidateAudience = _authOptions.ValidateAudience,
+                    ValidAudiences = validAudiences
                 };
             });
 
@@ -286,7 +298,7 @@ namespace Steamfitter.Api
 
         private void ApplyPolicies(IServiceCollection services)
         {
-            services.AddAuthorizationPolicy();
+            services.AddAuthorizationPolicy(_authOptions);
         }
     }
 }

--- a/Steamfitter.Api/appsettings.json
+++ b/Steamfitter.Api/appsettings.json
@@ -40,7 +40,9 @@
     "ClientId": "steamfitter.swagger",
     "ClientName": "Steamfitter Swagger UI",
     "ClientSecret": "",
-    "RequireHttpsMetadata": false
+    "RequireHttpsMetadata": false,
+    "ValidateAudience": true,
+    "ValidAudiences": [] // Defaults to AuthorizationScope if null or empty
   },
   "ResourceOwnerAuthorization": {
     "Authority": "http://localhost:5000",
@@ -109,6 +111,6 @@
     ]
   },
   "Files": {
-    "LocalDirectory" : "/tmp/"
+    "LocalDirectory": "/tmp/"
   }
 }


### PR DESCRIPTION
- support scope claims as array or single space-delimited string
- adds ValidateAudience and ValidAudiences settings
  - allows for more granular control of token validation settings
  - defaults to previous behavior