### PR TITLE
Allow user to set HTTP request headers for HTTP tasks

### DIFF
--- a/Steamfitter.Api/Infrastructure/Extensions/ApiClientsExtensions.cs
+++ b/Steamfitter.Api/Infrastructure/Extensions/ApiClientsExtensions.cs
@@ -16,7 +16,11 @@ namespace Steamfitter.Api.Infrastructure.Extensions
         {
             var client = httpClientFactory.CreateClient();
             client.BaseAddress = new Uri(apiUrl);
-            client.DefaultRequestHeaders.Add("authorization", $"{tokenResponse.TokenType} {tokenResponse.AccessToken}");
+            // Only add the header if the token was passed
+            if (tokenResponse != null)
+            {
+                client.DefaultRequestHeaders.Add("authorization", $"{tokenResponse.TokenType} {tokenResponse.AccessToken}");
+            }
             return client;
         }
 

--- a/Steamfitter.Api/Infrastructure/Options/VmProcessingOptions.cs
+++ b/Steamfitter.Api/Infrastructure/Options/VmProcessingOptions.cs
@@ -19,5 +19,6 @@ namespace Steamfitter.Api.Infrastructure.Options
         public int TaskProcessMaxWaitSeconds { get; set; }
         public int ExpirationCheckSeconds { get; set; }
         public Dictionary<string, string> ApiParameters { get; set; }
+        public Dictionary<string, string> HttpHeaderReplacements { get; set; }
     }
 }

--- a/Steamfitter.Api/appsettings.json
+++ b/Steamfitter.Api/appsettings.json
@@ -75,6 +75,7 @@
     "TaskProcessIntervalMilliseconds": 5000,
     "TaskProcessMaxWaitSeconds": 120,
     "ExpirationCheckSeconds": 30,
+    "HttpHeaderReplacements": {},
     "ApiParameters": {}
   },
   "ApplicationInsights": {

--- a/Steamfitter.Api/availableCommands.json
+++ b/Steamfitter.Api/availableCommands.json
@@ -507,6 +507,12 @@
                     "display": "Body",
                     "hint": "The body to be passed to the POST request.",
                     "inputType": "textArea"
+                },
+                {
+                    "key": "Headers",
+                    "display": "Headers",
+                    "hint": "Request headers",
+                    "inputType": "textArea"
                 }
             ]
         },


### PR DESCRIPTION
* Crucible auth token will not be added to headers when the user supplies their own headers.
*  User can reference variables defined inside HttpHeaderReplacements section of appsetttings file.