### PR TITLE
Set scenarioStatus to ready when copied

### DIFF
--- a/Steamfitter.Api/Services/ScenarioService.cs
+++ b/Steamfitter.Api/Services/ScenarioService.cs
@@ -252,6 +252,7 @@ namespace Steamfitter.Api.Services
             newScenarioEntity.CreatedBy = _user.GetId();
             newScenarioEntity.Name = $"{oldScenarioEntity.Name} - {_user.Claims.FirstOrDefault(c => c.Type == "name").Value}";
             newScenarioEntity.OnDemand = true;
+            newScenarioEntity.Status = ScenarioStatus.ready;
 
             _context.Scenarios.Add(newScenarioEntity);
             await _context.SaveChangesAsync(ct);

--- a/Steamfitter.Api/Services/StackStormService.cs
+++ b/Steamfitter.Api/Services/StackStormService.cs
@@ -160,6 +160,12 @@ namespace Steamfitter.Api.Services
             var apiParameters = _options.ApiParameters;
             try
             {
+                if (apiParameters == null || !apiParameters.ContainsKey("clusters") || String.IsNullOrWhiteSpace(apiParameters["clusters"]))
+                {
+                    _logger.LogWarning("\"clusters\" appsetting value needs to be set in order to get Stackstorm VMs");
+                    return;
+                }
+
                 var clusters = apiParameters["clusters"].ToString().Split(",");
                 var vmListResult = await _stackStormConnector.VSphere.GetVmsWithUuid(clusters);
                 // add VM's to _vmList

--- a/Steamfitter.Api/Services/StackStormService.cs
+++ b/Steamfitter.Api/Services/StackStormService.cs
@@ -160,9 +160,8 @@ namespace Steamfitter.Api.Services
             var apiParameters = _options.ApiParameters;
             try
             {
-                if (apiParameters == null || !apiParameters.ContainsKey("clusters") || String.IsNullOrWhiteSpace(apiParameters["clusters"]))
+                if (!_hasVms)
                 {
-                    _logger.LogWarning("\"clusters\" appsetting value needs to be set in order to get Stackstorm VMs");
                     return;
                 }
 


### PR DESCRIPTION
Status was previously set to the original value.
Does not call GetVmsWithUuid when starting scenarion is _hasVms is false.