### PR TITLE
Updated dockerfile to use chiseled-containers

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+# directories
+**/bin/
+**/obj/
+**/out/
+
+# files
+Dockerfile*
+**/*.md
+appsettings.*.json
+**/appsettings.*.json

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,6 +15,7 @@ jobs:
     uses: cmu-sei/Crucible-Github-Actions/.github/workflows/docker-build.yaml@docker-v1.0
     with:
       imageName: cmusei/steamfitter-api
+      additionalTarget: debug
     secrets:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
       DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,27 +1,38 @@
-#
-#multi-stage target: dev
-#
-FROM mcr.microsoft.com/dotnet/sdk:8.0 AS dev
+# Adapted from https://github.com/dotnet/dotnet-docker/blob/main/samples/aspnetapp/Dockerfile.chiseled
 
-ENV ASPNETCORE_HTTP_PORTS=4300
-ENV ASPNETCORE_ENVIRONMENT=DEVELOPMENT
+# Build stage
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+ARG TARGETARCH
+WORKDIR /source
 
-COPY . /app
+# Copy project files and restore as distinct layers
+COPY --link Steamfitter.Api/*.csproj ./Steamfitter.Api/
+COPY --link Steamfitter.Api.Data/*.csproj ./Steamfitter.Api.Data/
+COPY --link Steamfitter.Api.Migrations.PostgreSQL/*.csproj ./Steamfitter.Api.Migrations.PostgreSQL/
+WORKDIR /source/Steamfitter.Api
+RUN dotnet restore -a $TARGETARCH
+
+# Copy source code and publish app
+WORKDIR /source
+COPY --link . .
+WORKDIR /source/Steamfitter.Api
+RUN dotnet publish -a $TARGETARCH --no-restore -o /app
+
+# Debug Stage
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS debug
+ENV DOTNET_HOSTBUILDER__RELOADCONFIGCHANGE=false
+EXPOSE 8080
 WORKDIR /app
-RUN dotnet publish -c Release -o /app/dist
-CMD ["dotnet", "run"]
+COPY --link --from=build /app .
+USER $APP_UID
+ENTRYPOINT ["./Steamfitter.Api"]
 
-#
-#multi-stage target: prod
-#
-FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS prod
+# Production stage
+FROM mcr.microsoft.com/dotnet/aspnet:8.0-noble-chiseled AS prod
 ARG commit
 ENV COMMIT=$commit
 ENV DOTNET_HOSTBUILDER__RELOADCONFIGCHANGE=false
-COPY --from=dev /app/dist /app
-
+EXPOSE 8080
 WORKDIR /app
-ENV ASPNETCORE_HTTP_PORTS=80
-EXPOSE 80
-
-CMD ["dotnet", "Steamfitter.Api.dll"]
+COPY --link --from=build /app .
+ENTRYPOINT ["./Steamfitter.Api"]


### PR DESCRIPTION
Default docker image now uses the .NET 8 chiseled container image as a base. This defaults to a non-root user and port 8080 and is a minimal container without a shell, for increased security. If deploying through Helm, update to the latest Helm chart version with this release to support these changes. You may need to adjust NFS file permissions if mounting any NFS volumes.

All release images going forward will default to the non-root chiseled image. There will also be an image of the same tag, with "-debug" appended to it that will have a base of the non-root, standard image with a shell. This can be used for debugging issues, if necessary. If you need to use a root user, change the security context in your deployment infrastructure for this container.