### PR TITLE
Adds OpenTelemetry via Crucible Service Defaults

### DIFF
--- a/Steamfitter.Api/Steamfitter.Api.csproj
+++ b/Steamfitter.Api/Steamfitter.Api.csproj
@@ -41,6 +41,7 @@
     <PackageReference Include="AspNetCore.HealthChecks.Sqlite" Version="9.0.0" />
     <PackageReference Include="Stackstorm.Connector" Version="2.5.0"/>
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.2" />
+    <PackageReference Include="Crucible.Common.ServiceDefaults" Version="0.0.2"/>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Steamfitter.Api.Data\Steamfitter.Api.Data.csproj"/>

--- a/Steamfitter.Api/appsettings.json
+++ b/Steamfitter.Api/appsettings.json
@@ -85,6 +85,13 @@
   "ApplicationInsights": {
     "ConnectionString": ""
   },
+  "OpenTelemetry": {
+    "AddAlwaysOnTracingSampler": false,
+    "AddConsoleExporter": false,
+    "AddPrometheusExporter": false,
+    "IncludeDefaultActivitySources": true,
+    "IncludeDefaultMeters": true
+  },
   "SignalR": {
     "EnableStatefulReconnect": true,
     "StatefulReconnectBufferSizeBytes": 100000


### PR DESCRIPTION
Adds OpenTelemetry with Crucible ServiceDefaults implementation

- Adds ServiceDefaults settings to appsettings.json, allowing the user to specify options for the ServiceDefaults library
- Adjust Startup.cs to configure Otel via ServiceDefaults


Tested using Crucible Dev Container - Deployed Blueprint profile and observed all metrics, traces, and structured logs appearing in the Aspire Dashboard as intended.

Based changes made on the similar [PR to Blueprint.Api](https://github.com/cmu-sei/Blueprint.Api/pull/140).

Helm values will need to be updated to reflect the new OpenTelemetry settings. I can handle that in the Helm chart PR that is created once the changes are released.