### PR TITLE
Standardize launchUrl to 'api' for Aspire dashboard

### DIFF
--- a/Steamfitter.Api/Properties/launchSettings.json
+++ b/Steamfitter.Api/Properties/launchSettings.json
@@ -3,7 +3,7 @@
     "Steamfitter.Api": {
       "commandName": "Project",
       "launchBrowser": true,
-      "launchUrl": "http://localhost:4400/api",
+      "launchUrl": "api",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       },


### PR DESCRIPTION
Changed launchUrl from 'http://localhost:4400/api' to 'api' to ensure consistent URL display in the .NET Aspire dashboard.