### PR TITLE
Update to Crucible.Common.EntityEvents 0.2.0

### DIFF
--- a/Steamfitter.Api.Data/Steamfitter.Api.Data.csproj
+++ b/Steamfitter.Api.Data/Steamfitter.Api.Data.csproj
@@ -8,6 +8,6 @@
   <ItemGroup>
     <PackageReference Include="MediatR" Version="12.4.1" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.0" />
-    <PackageReference Include="Crucible.Common.EntityEvents" Version="0.1.0" />
+    <PackageReference Include="Crucible.Common.EntityEvents" Version="0.2.0" />
   </ItemGroup>
 </Project>

--- a/Steamfitter.Api.Data/SteamfitterContext.cs
+++ b/Steamfitter.Api.Data/SteamfitterContext.cs
@@ -13,6 +13,7 @@ using System.Collections.Generic;
 using MediatR;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Crucible.Common.EntityEvents;
 using Crucible.Common.EntityEvents.Abstractions;
 
@@ -68,14 +69,23 @@ namespace Steamfitter.Api.Data
             return await base.SaveChangesAsync(ct);
         }
 
-        protected override async Task PublishEventsAsync(CancellationToken cancellationToken)
+        public override async Task PublishEventsAsync(IReadOnlyList<IEntityEvent> events, CancellationToken cancellationToken)
         {
-            if (EntityEvents.Count > 0 && ServiceProvider is not null)
+            if (ServiceProvider is not null)
             {
                 var mediator = ServiceProvider.GetRequiredService<IMediator>();
-                foreach (var evt in EntityEvents.Cast<INotification>())
+                var logger = ServiceProvider.GetRequiredService<ILogger<SteamfitterContext>>();
+
+                foreach (var evt in events.Cast<INotification>())
                 {
-                    await mediator.Publish(evt, cancellationToken);
+                    try
+                    {
+                        await mediator.Publish(evt, cancellationToken);
+                    }
+                    catch (Exception ex)
+                    {
+                        logger.LogError(ex, "Error publishing entity event {EventType}", evt.GetType().Name);
+                    }
                 }
             }
         }


### PR DESCRIPTION
Adapt to breaking change in Crucible.Common.EntityEvents:

- PublishEventsAsync now receives events as a parameter instead of reading from this.EntityEvents.
- Adds per-event error isolation with try/catch and ILogger so a single handler failure doesn't block remaining events from being published.