### PR TITLE
Fix Moid/VmName placeholder replacement missing from UpdateAsync

### DIFF
--- a/Steamfitter.Api/Services/TaskService.cs
+++ b/Steamfitter.Api/Services/TaskService.cs
@@ -351,6 +351,14 @@ namespace Steamfitter.Api.Services
                 }
                 taskForm.VmMask = vmIdString.Remove(vmIdString.Count() - 1);
             }
+            if (taskForm.ActionParameters.Keys.Any(key => key == "Moid"))
+            {
+                taskForm.ActionParameters["Moid"] = "{moid}";
+            }
+            if (taskForm.ActionParameters.Keys.Any(key => key == "VmName"))
+            {
+                taskForm.ActionParameters["VmName"] = "{VmName}";
+            }
 
             _mapper.Map(taskForm, taskToUpdate);
             taskToUpdate.DateModified = DateTime.UtcNow;


### PR DESCRIPTION
UpdateAsync was missing the logic to set Moid to "{moid}" and VmName to "{VmName}" in action parameters, which CreateAsync already had. When a user changes the task action (e.g., power on to power off and back), the UI rebuilds action parameters with empty defaults. Without this fix, the empty Moid is persisted, causing GUID parse errors during StackStorm execution.