### PR TITLE
Surface Player VM API errors instead of showing misleading VM mask message

### DIFF
--- a/Steamfitter.Api/Infrastructure/Extensions/VmApiExtensions.cs
+++ b/Steamfitter.Api/Infrastructure/Extensions/VmApiExtensions.cs
@@ -25,15 +25,8 @@ namespace Steamfitter.Api.Infrastructure.Extensions
 
         public static async Task<IEnumerable<Player.Vm.Api.Models.Vm>> GetViewVmsAsync(PlayerVmApiClient playerVmApiClient, Guid viewId, CancellationToken ct)
         {
-            try
-            {
-                var vms = (await playerVmApiClient.GetViewVmsAsync(viewId, null, true, false, ct)) as IEnumerable<Player.Vm.Api.Models.Vm>;
-                return vms;
-            }
-            catch (Exception)
-            {
-                return null;
-            }
+            var vms = (await playerVmApiClient.GetViewVmsAsync(viewId, null, true, false, ct)) as IEnumerable<Player.Vm.Api.Models.Vm>;
+            return vms;
         }
 
     }

--- a/Steamfitter.Api/Services/TaskExecutionService.cs
+++ b/Steamfitter.Api/Services/TaskExecutionService.cs
@@ -377,9 +377,15 @@ namespace Steamfitter.Api.Services
                         }
                     }
                 }
-                catch (System.Exception)
+                catch (System.Exception ex)
                 {
-                    _logger.LogDebug($"CreateResultsAsync - No VM's found in view {viewId}");
+                    _logger.LogError(ex, $"CreateResultsAsync - Failed to get VMs from Player VM API for view {viewId}");
+                    var resultEntity = NewResultEntity(taskToExecute, userId);
+                    resultEntity.ActualOutput = $"Failed to get VMs from Player VM API for view {viewId}.";
+                    resultEntity.Status = Data.TaskStatus.error;
+                    resultEntity.StatusDate = DateTime.UtcNow;
+                    resultEntities.Add(resultEntity);
+                    return resultEntities;
                 }
                 // make sure we are only matching a SINGLE view
                 if (vmList.Count() > 0)


### PR DESCRIPTION
Remove silent exception swallowing in VmApiExtensions.GetViewVmsAsync and update TaskExecutionService.CreateResultsAsync to log the actual error at Error level and return a result with error status and a meaningful message instead of falling through to "No matched VMs".