### PR TITLE
 Add optional Id field to ScenarioForm to support pre-generated IDs

### DIFF
--- a/Steamfitter.Api.Client/Steamfitter.Api.Contracts.cs
+++ b/Steamfitter.Api.Client/Steamfitter.Api.Contracts.cs
@@ -2323,6 +2323,9 @@ namespace Steamfitter.Api.Client
     public partial class ScenarioForm
     {
 
+        [System.Text.Json.Serialization.JsonPropertyName("id")]
+        public System.Guid? Id { get; set; }
+
         [System.Text.Json.Serialization.JsonPropertyName("name")]
         public string Name { get; set; }
 

--- a/Steamfitter.Api/Services/ScenarioService.cs
+++ b/Steamfitter.Api/Services/ScenarioService.cs
@@ -133,6 +133,7 @@ namespace Steamfitter.Api.Services
         public async STT.Task<ViewModels.Scenario> CreateAsync(ViewModels.ScenarioForm scenarioForm, CancellationToken ct)
         {
             var scenarioEntity = _mapper.Map<ScenarioEntity>(scenarioForm);
+            scenarioEntity.Id = scenarioForm.Id.HasValue ? scenarioForm.Id.Value : Guid.NewGuid();
             scenarioEntity.DateCreated = DateTime.UtcNow;
             scenarioEntity.CreatedBy = _user.GetId();
             scenarioEntity.StartDate = scenarioEntity.StartDate.ToUniversalTime();

--- a/Steamfitter.Api/ViewModels/Scenario.cs
+++ b/Steamfitter.Api/ViewModels/Scenario.cs
@@ -42,6 +42,7 @@ namespace Steamfitter.Api.ViewModels
 
     public class ScenarioForm
     {
+        public Guid? Id { get; set; }
         public string Name { get; set; }
         public string Description { get; set; }
         public DateTime StartDate { get; set; }


### PR DESCRIPTION
Allow callers to supply a pre-generated GUID when creating a scenario, so Blueprint can set the SteamfitterScenarioId before calling the API  and avoid a round-trip to discover the created ID.