### PR TITLE
Endpoint authorization improvements

### DIFF
--- a/Steamfitter.Api/Controllers/ResultController.cs
+++ b/Steamfitter.Api/Controllers/ResultController.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Net;
 using System.Threading;
 using STT = System.Threading.Tasks;
@@ -132,10 +133,13 @@ namespace Steamfitter.Api.Controllers
         [SwaggerOperation(OperationId = "getVmResults")]
         public async STT.Task<IActionResult> GetByVmId(Guid id, CancellationToken ct)
         {
-            if (!await _authorizationService.AuthorizeAsync([SystemPermission.ViewScenarios], ct))
+            var hasSystemPermission = await _authorizationService.AuthorizeAsync([SystemPermission.ViewScenarios], ct);
+            var authorizedScenarioIds = _authorizationService.GetAuthorizedScenarioIds();
+
+            if (!hasSystemPermission && !authorizedScenarioIds.Any())
                 throw new ForbiddenException();
 
-            var list = await _ResultService.GetByVmIdAsync(id, ct);
+            var list = await _ResultService.GetByVmIdAsync(id, hasSystemPermission, authorizedScenarioIds, ct);
             return Ok(list);
         }
 

--- a/Steamfitter.Api/Controllers/ResultController.cs
+++ b/Steamfitter.Api/Controllers/ResultController.cs
@@ -179,7 +179,7 @@ namespace Steamfitter.Api.Controllers
         public async STT.Task<IActionResult> Create([FromBody] SAVM.Result result, CancellationToken ct)
         {
             if (result.TaskId == null ||
-                !await _authorizationService.AuthorizeAsync<ViewModels.Task>(result.TaskId, [SystemPermission.ViewScenarios], [ScenarioPermission.ViewScenario], ct))
+                !await _authorizationService.AuthorizeAsync<ViewModels.Task>(result.TaskId, [SystemPermission.EditScenarios], [ScenarioPermission.EditScenario], ct))
                 throw new ForbiddenException();
 
             var createdResult = await _ResultService.CreateAsync(result, ct);
@@ -202,7 +202,7 @@ namespace Steamfitter.Api.Controllers
         [SwaggerOperation(OperationId = "updateResult")]
         public async STT.Task<IActionResult> Update([FromRoute] Guid id, [FromBody] SAVM.Result result, CancellationToken ct)
         {
-            if (!await _authorizationService.AuthorizeAsync<ViewModels.Result>(id, [SystemPermission.ViewScenarios], [ScenarioPermission.ViewScenario], ct))
+            if (!await _authorizationService.AuthorizeAsync<ViewModels.Result>(id, [SystemPermission.EditScenarios], [ScenarioPermission.EditScenario], ct))
                 throw new ForbiddenException();
 
             var updatedResult = await _ResultService.UpdateAsync(id, result, ct);
@@ -224,7 +224,7 @@ namespace Steamfitter.Api.Controllers
         [SwaggerOperation(OperationId = "deleteResult")]
         public async STT.Task<IActionResult> Delete(Guid id, CancellationToken ct)
         {
-            if (!await _authorizationService.AuthorizeAsync<ViewModels.Result>(id, [SystemPermission.ViewScenarios], [ScenarioPermission.ViewScenario], ct))
+            if (!await _authorizationService.AuthorizeAsync<ViewModels.Result>(id, [SystemPermission.ManageScenarios], [ScenarioPermission.ManageScenario], ct))
                 throw new ForbiddenException();
 
             await _ResultService.DeleteAsync(id, ct);

--- a/Steamfitter.Api/Controllers/ResultController.cs
+++ b/Steamfitter.Api/Controllers/ResultController.cs
@@ -132,6 +132,9 @@ namespace Steamfitter.Api.Controllers
         [SwaggerOperation(OperationId = "getVmResults")]
         public async STT.Task<IActionResult> GetByVmId(Guid id, CancellationToken ct)
         {
+            if (!await _authorizationService.AuthorizeAsync([SystemPermission.ViewScenarios], ct))
+                throw new ForbiddenException();
+
             var list = await _ResultService.GetByVmIdAsync(id, ct);
             return Ok(list);
         }

--- a/Steamfitter.Api/Controllers/TaskController.cs
+++ b/Steamfitter.Api/Controllers/TaskController.cs
@@ -420,6 +420,17 @@ namespace Steamfitter.Api.Controllers
                 var task = await _taskService.GetAsync(id, ct);
                 if (task == null)
                     throw new EntityNotFoundException<SAVM.Task>();
+
+                if (task.ScenarioId != null)
+                {
+                    if (!await _authorizationService.AuthorizeAsync<SAVM.Scenario>(task.ScenarioId, [SystemPermission.EditScenarios], [ScenarioPermission.EditScenario], ct))
+                        throw new ForbiddenException();
+                }
+                else if (task.ScenarioTemplateId != null)
+                {
+                    if (!await _authorizationService.AuthorizeAsync<SAVM.ScenarioTemplate>(task.ScenarioTemplateId, [SystemPermission.EditScenarioTemplates], [ScenarioTemplatePermission.EditScenarioTemplate], ct))
+                        throw new ForbiddenException();
+                }
             }
             else if (locationType == "scenario")
             {

--- a/Steamfitter.Api/Services/ResultService.cs
+++ b/Steamfitter.Api/Services/ResultService.cs
@@ -24,7 +24,7 @@ namespace Steamfitter.Api.Services
         STT.Task<IEnumerable<ViewModels.Result>> GetByScenarioIdAsync(Guid scenarioId, CancellationToken ct);
         STT.Task<IEnumerable<ViewModels.Result>> GetByViewIdAsync(Guid viewId, CancellationToken ct);
         STT.Task<IEnumerable<ViewModels.Result>> GetByUserIdAsync(Guid userId, CancellationToken ct);
-        STT.Task<IEnumerable<ViewModels.Result>> GetByVmIdAsync(Guid vmId, CancellationToken ct);
+        STT.Task<IEnumerable<ViewModels.Result>> GetByVmIdAsync(Guid vmId, bool hasSystemPermission, IEnumerable<Guid> authorizedScenarioIds, CancellationToken ct);
         STT.Task<IEnumerable<ViewModels.Result>> GetByTaskIdAsync(Guid taskId, CancellationToken ct);
         STT.Task<ViewModels.Result> CreateAsync(ViewModels.Result result, CancellationToken ct);
         STT.Task<ViewModels.Result> UpdateAsync(Guid id, ViewModels.Result result, CancellationToken ct);
@@ -78,11 +78,20 @@ namespace Steamfitter.Api.Services
             return _mapper.Map<IEnumerable<ViewModels.Result>>(results.OrderByDescending(r => r.StatusDate));
         }
 
-        public async STT.Task<IEnumerable<ViewModels.Result>> GetByVmIdAsync(Guid vmId, CancellationToken ct)
+        public async STT.Task<IEnumerable<ViewModels.Result>> GetByVmIdAsync(Guid vmId, bool hasSystemPermission, IEnumerable<Guid> authorizedScenarioIds, CancellationToken ct)
         {
             var results = _context.Results.Where(dt => dt.VmId == vmId);
 
-            return _mapper.Map<IEnumerable<ViewModels.Result>>(results);
+            if (!hasSystemPermission)
+            {
+                var authorizedScenarioIdList = authorizedScenarioIds.ToList();
+                var authorizedTaskIds = _context.Tasks
+                    .Where(t => t.ScenarioId.HasValue && authorizedScenarioIdList.Contains(t.ScenarioId.Value))
+                    .Select(t => (Guid?)t.Id);
+                results = results.Where(r => authorizedTaskIds.Contains(r.TaskId));
+            }
+
+            return _mapper.Map<IEnumerable<ViewModels.Result>>(await results.ToListAsync(ct));
         }
 
         public async STT.Task<IEnumerable<SAVM.Result>> GetByTaskIdAsync(Guid taskId, CancellationToken ct)


### PR DESCRIPTION
  Summary                                                                                                                                                                                                                                                                              
                                                                                                                                                                                                                                                                                       
  - Add authorization checks to task update and delete endpoints — previously any authenticated user could modify or delete any task by ID regardless of scenario membership (CWE-862, verified by exploit test: contentdev user successfully renamed a task to "HACKED" on main,
  blocked with 403 on this branch)                                                                                                                                                                                                                                                     
  - Add missing authorization check to GET /api/vms/{id}/Results — the only results endpoint with no auth, exposing command execution history for any VM to any authenticated user
  - Tighten Result create/update/delete endpoints from ViewScenarios (read-level) to EditScenarios/ManageScenarios (write-level) — these endpoints are not used by the UI but should enforce proper write permissions

  Test plan

  - PUT /api/tasks/{id} as contentdev returns 403 (returned 200 on main)
  - GET /api/vms/{id}/Results as contentdev returns 403
  - Admin user can still update/delete tasks normally
  - Task execution and manual task runs unaffected (results created internally, not through Result endpoints)