### PR TITLE
Fix/xapi moreinfo double slash

### DIFF
--- a/Steamfitter.Api/Services/XApiService.cs
+++ b/Steamfitter.Api/Services/XApiService.cs
@@ -162,7 +162,7 @@ namespace Steamfitter.Api.Services
 
             if (!string.IsNullOrWhiteSpace(_xApiOptions.UiUrl))
             {
-                activity.definition.moreInfo = new Uri(_xApiOptions.UiUrl + "/scenario/" + scenarioId);
+                activity.definition.moreInfo = new Uri(_xApiOptions.UiUrl.TrimEnd('/') + "/scenario/" + scenarioId);
             }
 
             var context = new Context();
@@ -211,7 +211,7 @@ namespace Steamfitter.Api.Services
 
             if (!string.IsNullOrWhiteSpace(_xApiOptions.UiUrl))
             {
-                activity.definition.moreInfo = new Uri(_xApiOptions.UiUrl + "/scenario/" + scenarioId);
+                activity.definition.moreInfo = new Uri(_xApiOptions.UiUrl.TrimEnd('/') + "/scenario/" + scenarioId);
             }
 
             var context = new Context();

--- a/Steamfitter.Api/Services/XApiService.cs
+++ b/Steamfitter.Api/Services/XApiService.cs
@@ -320,6 +320,35 @@ namespace Steamfitter.Api.Services
             parentActivity.definition.description = new LanguageMap();
             parentActivity.definition.description.Add("en-US", scenario.Description ?? scenario.Name);
             contextActivities.parent = new List<Activity> { parentActivity };
+
+            var groupingList = new List<Activity>();
+            var moveGroupMatch = System.Text.RegularExpressions.Regex.Match(task.Name ?? "", @"^(\d+)-(\d+)\s");
+            if (moveGroupMatch.Success)
+            {
+                var moveNumber = int.Parse(moveGroupMatch.Groups[1].Value);
+                var groupNumber = int.Parse(moveGroupMatch.Groups[2].Value);
+
+                var moveActivity = new Activity();
+                moveActivity.id = _xApiOptions.ApiUrl + "scenarios/" + scenarioId + "/move/" + moveNumber;
+                moveActivity.definition = new ActivityDefinition();
+                moveActivity.definition.type = new Uri("http://id.tincanapi.com/activitytype/collection-simple");
+                moveActivity.definition.name = new LanguageMap();
+                moveActivity.definition.name.Add("en-US", $"Move {moveNumber}");
+                groupingList.Add(moveActivity);
+
+                var groupActivity = new Activity();
+                groupActivity.id = _xApiOptions.ApiUrl + "scenarios/" + scenarioId + "/move/" + moveNumber + "/group/" + groupNumber;
+                groupActivity.definition = new ActivityDefinition();
+                groupActivity.definition.type = new Uri("http://id.tincanapi.com/activitytype/collection-simple");
+                groupActivity.definition.name = new LanguageMap();
+                groupActivity.definition.name.Add("en-US", $"Group {groupNumber}");
+                groupingList.Add(groupActivity);
+            }
+            if (groupingList.Count > 0)
+            {
+                contextActivities.grouping = groupingList;
+            }
+
             context.contextActivities = contextActivities;
 
             var statement = new Statement();

--- a/Steamfitter.Api/Services/XApiService.cs
+++ b/Steamfitter.Api/Services/XApiService.cs
@@ -277,12 +277,39 @@ namespace Steamfitter.Api.Services
             activity.definition.description = new LanguageMap();
             activity.definition.description.Add("en-US", task.Description ?? task.Name);
 
+            var activityExtensions = new Newtonsoft.Json.Linq.JObject();
+            activityExtensions["https://crucible.sei.cmu.edu/xapi/extensions/taskAction"] = task.Action.ToString();
+            if (!string.IsNullOrWhiteSpace(task.VmMask))
+            {
+                activityExtensions["https://crucible.sei.cmu.edu/xapi/extensions/vmMask"] = task.VmMask;
+            }
+            if (!string.IsNullOrWhiteSpace(task.ApiUrl))
+            {
+                activityExtensions["https://crucible.sei.cmu.edu/xapi/extensions/apiUrl"] = task.ApiUrl;
+            }
+            if (!string.IsNullOrWhiteSpace(task.ExpectedOutput))
+            {
+                activityExtensions["https://crucible.sei.cmu.edu/xapi/extensions/expectedOutput"] = task.ExpectedOutput;
+            }
+            activity.definition.extensions = new TinCan.Extensions(activityExtensions);
+
+            var result = new Result();
+            result.completion = task.IsComplete;
+            result.success = task.Status == Data.TaskStatus.succeeded;
+            if (task.Score > 0)
+            {
+                result.score = new Score();
+                result.score.raw = task.ScoreEarned;
+                result.score.max = task.Score;
+                result.score.min = 0;
+                result.score.scaled = task.Score > 0 ? (double)task.ScoreEarned / task.Score : 0;
+            }
+
             var context = new Context();
             context.platform = _xApiContext.platform;
             context.language = _xApiContext.language;
-            context.registration = scenarioId; // Group statements by scenario session
+            context.registration = scenarioId;
 
-            // Add scenario as parent activity
             var contextActivities = new ContextActivities();
             var parentActivity = new Activity();
             parentActivity.id = _xApiOptions.ApiUrl + "scenarios/" + scenarioId;
@@ -299,6 +326,7 @@ namespace Steamfitter.Api.Services
             statement.actor = _agent;
             statement.verb = verb;
             statement.target = activity;
+            statement.result = result;
             statement.context = context;
 
             return await QueueStatementAsync(statement, verb.id, activity.id, scenarioId, ct);


### PR DESCRIPTION
  Summary

  - Fix double-slash in moreInfo URLs caused by UiUrl ending with / concatenated with paths starting with / — uses TrimEnd('/') on all moreInfo URL constructions
  - Add activity extensions to TaskExecutedAsync statements: taskAction (http_get, guest_process_run, etc.), vmMask, apiUrl, and expectedOutput
  - Add result block with completion, success, and score (raw/max/min/scaled) when scoring is configured
  - Parse Blueprint's MM-GG task name prefix (e.g., 01-02 STARTEX) to add move and group as contextActivities.grouping activities, matching the convention used by CITE and
  Gallery

  Context                                                                                                                                                                   
  Blueprint's assessor view aggregates xAPI from all Crucible apps to show exercise evidence. These changes give Steamfitter statements enough context for the assessor view
   to:                                   
  - Place statements under the correct move and group
  - Display the task type and VM target
  - Show pass/fail status and scoring

  Test plan

  - Verified moreInfo URLs no longer contain //
  - Verified taskAction, apiUrl, expectedOutput appear in statement extensions
  - Verified result.completion and result.success present on task statements
  - Verified tasks with MM-GG prefix produce move/group grouping activities
  - Verified tasks without the prefix produce no grouping (no regression)