### PR TITLE
Add Scenario Memberships for users sent in ScenarioCloneOptions

### DIFF
--- a/Steamfitter.Api.Client/Steamfitter.Api.Contracts.cs
+++ b/Steamfitter.Api.Client/Steamfitter.Api.Contracts.cs
@@ -2314,8 +2314,38 @@ namespace Steamfitter.Api.Client
         [System.Text.Json.Serialization.JsonPropertyName("viewId")]
         public System.Guid? ViewId { get; set; }
 
+        /// <summary>
+        /// Ids of the Users to add to the new Scenario as Members. Deprecated as of client version 3.10.0 in favor of Users, which also carries the name to create a missing Steamfitter User with. Ids sent here are still honored, but a User created from one of them is named after its Id.
+        /// </summary>
         [System.Text.Json.Serialization.JsonPropertyName("userIds")]
         public System.Collections.Generic.ICollection<System.Guid> UserIds { get; set; }
+
+        /// <summary>
+        /// The Users to add to the new Scenario as Members. A Steamfitter User record is created for any of these that has not been seen before, so that a user who has never signed in to Steamfitter can still be given a Scenario Membership.
+        /// </summary>
+        [System.Text.Json.Serialization.JsonPropertyName("users")]
+        public System.Collections.Generic.ICollection<ScenarioCloneUser> Users { get; set; }
+
+    }
+
+    /// <summary>
+    /// A User to add to a cloned Scenario, including the name to use if the User has to be created.
+    /// </summary>
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "14.6.2.0 (NJsonSchema v11.5.2.0 (Newtonsoft.Json v13.0.0.0))")]
+    public partial class ScenarioCloneUser
+    {
+
+        /// <summary>
+        /// Id of the User.
+        /// </summary>
+        [System.Text.Json.Serialization.JsonPropertyName("id")]
+        public System.Guid Id { get; set; }
+
+        /// <summary>
+        /// Name of the User, used only if the User has to be created.
+        /// </summary>
+        [System.Text.Json.Serialization.JsonPropertyName("name")]
+        public string Name { get; set; }
 
     }
 

--- a/Steamfitter.Api/Services/ScenarioService.cs
+++ b/Steamfitter.Api/Services/ScenarioService.cs
@@ -198,12 +198,6 @@ namespace Steamfitter.Api.Services
                     scenarioEntity.ViewId = options.ViewId;
                 }
 
-                if (options.UserIds != null && options.UserIds.Any())
-                {
-                    // TODO: use the new permission/role/group to do this
-                    // await AddUsersAsync(scenarioEntity.Id, options.UserIds, ct);
-                }
-
                 await _context.SaveChangesAsync(ct);
             }
             var createOwnerMembership = new ScenarioMembershipEntity() {
@@ -213,6 +207,12 @@ namespace Steamfitter.Api.Services
             };
             await _context.ScenarioMemberships.AddAsync(createOwnerMembership, ct);
             await _context.SaveChangesAsync(ct);
+
+            if (options != null)
+            {
+                await AddScenarioMembersAsync(scenarioEntity.Id, options, ct);
+            }
+
             await transaction.CommitAsync(ct);
             var scenario = _mapper.Map<SAVM.Scenario>(scenarioEntity);
 
@@ -372,6 +372,82 @@ namespace Steamfitter.Api.Services
             await _context.SaveChangesAsync(ct);
 
             return newDefaultVmCredentialId;
+        }
+
+        /// <summary>
+        /// Gives each User named in the clone options a Member Membership on the new Scenario,
+        /// creating the Steamfitter User record first if the User has never been seen before.
+        /// The calling account keeps the Manager Membership it was given as the creator.
+        /// </summary>
+        private async STT.Task AddScenarioMembersAsync(Guid scenarioId, SAVM.ScenarioCloneOptions options, CancellationToken ct)
+        {
+            // Users carries a name to create missing Users with, UserIds does not, so let Users win
+            var requestedNamesByUserId = new Dictionary<Guid, string>();
+
+            if (options.UserIds != null)
+            {
+                foreach (var userId in options.UserIds.Where(x => x != Guid.Empty))
+                {
+                    requestedNamesByUserId[userId] = null;
+                }
+            }
+
+            if (options.Users != null)
+            {
+                foreach (var user in options.Users.Where(x => x != null && x.Id != Guid.Empty))
+                {
+                    requestedNamesByUserId[user.Id] = string.IsNullOrWhiteSpace(user.Name) ? null : user.Name.Trim();
+                }
+            }
+
+            // the caller is already a member as the creator of the Scenario
+            requestedNamesByUserId.Remove(_user.GetId());
+
+            if (!requestedNamesByUserId.Any())
+                return;
+
+            var userIds = requestedNamesByUserId.Keys.ToList();
+            var existingUsers = await _context.Users
+                .Where(x => userIds.Contains(x.Id))
+                .ToListAsync(ct);
+
+            foreach (var requestedUser in requestedNamesByUserId)
+            {
+                var userEntity = existingUsers.SingleOrDefault(x => x.Id == requestedUser.Key);
+
+                if (userEntity == null)
+                {
+                    _context.Users.Add(new UserEntity()
+                    {
+                        Id = requestedUser.Key,
+                        Name = requestedUser.Value ?? requestedUser.Key.ToString(),
+                        CreatedBy = _user.GetId()
+                    });
+                }
+                else if (requestedUser.Value != null && userEntity.Name != requestedUser.Value)
+                {
+                    userEntity.Name = requestedUser.Value;
+                    userEntity.DateModified = DateTime.UtcNow;
+                    userEntity.ModifiedBy = _user.GetId();
+                }
+            }
+
+            var alreadyMemberUserIds = await _context.ScenarioMemberships
+                .Where(x => x.ScenarioId == scenarioId && x.UserId.HasValue && userIds.Contains(x.UserId.Value))
+                .Select(x => x.UserId.Value)
+                .ToListAsync(ct);
+
+            foreach (var userId in userIds.Where(x => !alreadyMemberUserIds.Contains(x)))
+            {
+                _context.ScenarioMemberships.Add(new ScenarioMembershipEntity()
+                {
+                    UserId = userId,
+                    ScenarioId = scenarioId,
+                    RoleId = ScenarioRoleDefaults.ScenarioMemberRoleId
+                });
+            }
+
+            await _context.SaveChangesAsync(ct);
         }
 
     }

--- a/Steamfitter.Api/ViewModels/Scenario.cs
+++ b/Steamfitter.Api/ViewModels/Scenario.cs
@@ -60,6 +60,31 @@ namespace Steamfitter.Api.ViewModels
     {
         public string NameSuffix { get; set; }
         public Guid? ViewId { get; set; }
+
+        /// <summary>
+        /// Ids of the Users to add to the new Scenario as Members. Deprecated as of client version 3.10.0 in favor of Users, which also carries the name to create a missing Steamfitter User with. Ids sent here are still honored, but a User created from one of them is named after its Id.
+        /// </summary>
         public List<Guid> UserIds { get; set; }
+
+        /// <summary>
+        /// The Users to add to the new Scenario as Members. A Steamfitter User record is created for any of these that has not been seen before, so that a user who has never signed in to Steamfitter can still be given a Scenario Membership.
+        /// </summary>
+        public List<ScenarioCloneUser> Users { get; set; }
+    }
+
+    /// <summary>
+    /// A User to add to a cloned Scenario, including the name to use if the User has to be created.
+    /// </summary>
+    public class ScenarioCloneUser
+    {
+        /// <summary>
+        /// Id of the User.
+        /// </summary>
+        public Guid Id { get; set; }
+
+        /// <summary>
+        /// Name of the User, used only if the User has to be created.
+        /// </summary>
+        public string Name { get; set; }
     }
 }


### PR DESCRIPTION
Add Scenario Memberships for users sent in ScenarioCloneOptions

  CreateFromScenarioTemplateAsync read options.UserIds but did nothing with it, so
  the only Membership on a cloned Scenario was the Manager Membership for the
  calling service account. A user who had never signed in to Steamfitter had no
  User record at all, so they got no Membership and the Scenario did not show up
  for them. ScenarioMembershipService.CreateAsync could not repair it afterward
  either, since it rejects a UserId that is not already a Steamfitter user.

  * Add ScenarioCloneUser { Id, Name } and ScenarioCloneOptions.Users, so a caller
    can supply the display name to create a missing Steamfitter User with
  * Create the Steamfitter User record for any supplied user that does not exist,
    and refresh the name of one that does
  * Give each supplied user a Member Membership on the new Scenario, skipping
    anyone who already has one
  * Preserve the caller's Manager Membership as the creator of the Scenario
  * Keep UserIds working for existing callers; a User created from a bare id is
    named after that id. Deprecated in favor of Users as of client 3.10.0
  * Regenerate Steamfitter.Api.Client contracts for the new field